### PR TITLE
fix: OVMS precision/device env config, permission fix, 2PC sync skip …

### DIFF
--- a/dine-in/.env.example
+++ b/dine-in/.env.example
@@ -17,7 +17,9 @@ LOG_LEVEL=INFO
 # Service Endpoints
 # -----------------------------------------------------------------------------
 OVMS_ENDPOINT=http://ovms-vlm:8000
-OVMS_MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct-ov-int8
+OVMS_MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
+VLM_PRECISION=int8
+VLM_DEVICE=GPU
 SEMANTIC_SERVICE_ENDPOINT=http://semantic-service:8080
 API_TIMEOUT=60
 

--- a/dine-in/Dockerfile
+++ b/dine-in/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
-    git && \
+    git \
+    gosu && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better layer caching
@@ -46,12 +47,14 @@ COPY configs/ ./configs/
 # Create results directory and set permissions
 RUN mkdir -p /app/results && chown -R appuser:appuser /app
 
-# Switch to non-root user
-USER appuser
+# Copy entrypoint script (runs as root to fix volume permissions, then drops to appuser)
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Expose ports
 EXPOSE 7860
 EXPOSE 8080
 
-# Run the combined application from src directory
+# Entrypoint fixes permissions and drops to appuser
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["python", "src/main.py"]

--- a/dine-in/docker-compose.yml
+++ b/dine-in/docker-compose.yml
@@ -46,8 +46,10 @@ services:
       - SERVICE_NAME=semantic-comparison-service
       - LOG_LEVEL=INFO
       - VLM_BACKEND=ovms
-      - OVMS_ENDPOINT=http://ovms-vlm:8000
-      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME:-Qwen/Qwen2.5-VL-7B-Instruct-ov-int8}
+      - OVMS_ENDPOINT=${OVMS_ENDPOINT}
+      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME}
+      - VLM_PRECISION=${VLM_PRECISION}
+      - VLM_DEVICE=${VLM_DEVICE}
       - CACHE_ENABLED=true
       - CACHE_BACKEND=memory
       - PROMETHEUS_ENABLED=true
@@ -83,7 +85,6 @@ services:
         - https_proxy=${HTTPS_PROXY}
         - no_proxy=${NO_PROXY}
     container_name: dinein_app
-    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "7861:7860"  # Gradio UI
       - "8083:8080"  # FastAPI
@@ -92,9 +93,11 @@ services:
       - ./results:/app/results
       - ./configs:/app/configs:ro
     environment:
-      - SEMANTIC_SERVICE_ENDPOINT=http://semantic-service:8080
-      - OVMS_ENDPOINT=http://ovms-vlm:8000
-      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME:-Qwen/Qwen2.5-VL-7B-Instruct-ov-int8}
+      - SEMANTIC_SERVICE_ENDPOINT=${SEMANTIC_SERVICE_ENDPOINT}
+      - OVMS_ENDPOINT=${OVMS_ENDPOINT}
+      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME}
+      - VLM_PRECISION=${VLM_PRECISION}
+      - VLM_DEVICE=${VLM_DEVICE}
       - METRICS_COLLECTOR_ENDPOINT=http://metrics-collector:8084
       - CONTAINER_RESULTS_PATH=/app/results
       - USECASE_1=dine-in-order-accuracy
@@ -127,7 +130,6 @@ services:
     profiles:
       - benchmark
       - worker
-    user: "${UID:-1000}:${GID:-1000}"
     deploy:
       replicas: ${WORKERS:-1}
     volumes:
@@ -141,9 +143,11 @@ services:
       - IMAGES_DIR=/app/images
       - ORDERS_FILE=/app/configs/orders.json
       - RESULTS_DIR=/app/results
-      - SEMANTIC_SERVICE_ENDPOINT=http://semantic-service:8080
-      - OVMS_ENDPOINT=http://ovms-vlm:8000
-      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME:-Qwen/Qwen2.5-VL-7B-Instruct-ov-int8}
+      - SEMANTIC_SERVICE_ENDPOINT=${SEMANTIC_SERVICE_ENDPOINT}
+      - OVMS_ENDPOINT=${OVMS_ENDPOINT}
+      - OVMS_MODEL_NAME=${OVMS_MODEL_NAME}
+      - VLM_PRECISION=${VLM_PRECISION}
+      - VLM_DEVICE=${VLM_DEVICE}
       - CONTAINER_RESULTS_PATH=/app/results
       - USECASE_1=dine-in-order-accuracy
       - NO_PROXY=localhost,127.0.0.1,ovms-vlm,semantic-service,host.docker.internal

--- a/dine-in/entrypoint.sh
+++ b/dine-in/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Fix ownership of mounted volumes that Docker may create as root
+# This runs as root before dropping to appuser
+if [ -d "/app/results" ]; then
+    chown -R appuser:appuser /app/results
+fi
+
+# Drop privileges and exec the CMD as appuser
+exec gosu appuser "$@"

--- a/dine-in/src/config.py
+++ b/dine-in/src/config.py
@@ -16,6 +16,8 @@ class ServiceConfig:
     """Service endpoint configurations"""
     ovms_endpoint: str
     ovms_model_name: str
+    vlm_precision: str
+    vlm_device: str
     semantic_service_endpoint: str
     metrics_collector_endpoint: str
     api_timeout: int
@@ -79,7 +81,9 @@ class ConfigManager:
         
         service_config = ServiceConfig(
             ovms_endpoint=os.getenv("OVMS_ENDPOINT", "http://ovms-vlm:8000"),
-            ovms_model_name=os.getenv("OVMS_MODEL_NAME", "Qwen/Qwen2.5-VL-7B-Instruct-ov-int8"),
+            ovms_model_name=os.getenv("OVMS_MODEL_NAME", "Qwen/Qwen2.5-VL-7B-Instruct"),
+            vlm_precision=os.getenv("VLM_PRECISION", "int8"),
+            vlm_device=os.getenv("VLM_DEVICE", "GPU"),
             semantic_service_endpoint=os.getenv("SEMANTIC_SERVICE_ENDPOINT", "http://semantic-service:8080"),
             metrics_collector_endpoint=os.getenv("METRICS_COLLECTOR_ENDPOINT", "http://metrics-collector:8084"),
             api_timeout=int(os.getenv("API_TIMEOUT", "300"))  # Extended for 7B model with inventory
@@ -107,6 +111,9 @@ class ConfigManager:
         )
         
         logger.info(f"Configuration loaded: OVMS={service_config.ovms_endpoint}, "
+                   f"Model={service_config.ovms_model_name}, "
+                   f"Precision={service_config.vlm_precision}, "
+                   f"Device={service_config.vlm_device}, "
                    f"Semantic={service_config.semantic_service_endpoint}, "
                    f"Benchmark={benchmark_config.enabled}")
 

--- a/take-away/.env.example
+++ b/take-away/.env.example
@@ -29,6 +29,8 @@ VLM_BACKEND=ovms
 # OVMS connection settings
 OVMS_ENDPOINT=http://ovms-vlm:8000
 OVMS_MODEL_NAME=Qwen/Qwen2.5-VL-7B-Instruct
+VLM_PRECISION=int8
+VLM_DEVICE=GPU
 OVMS_TIMEOUT=120
 
 # OpenVINO local settings (when VLM_BACKEND=openvino)

--- a/take-away/docker-compose.yaml
+++ b/take-away/docker-compose.yaml
@@ -108,6 +108,8 @@ services:
       # OVMS settings (when VLM_BACKEND=ovms)
       OVMS_ENDPOINT: ${OVMS_ENDPOINT:-http://ovms-vlm:8000}
       OVMS_MODEL_NAME: ${OVMS_MODEL_NAME:-Qwen/Qwen2.5-VL-7B-Instruct}
+      VLM_PRECISION: ${VLM_PRECISION:-int8}
+      VLM_DEVICE: ${VLM_DEVICE:-GPU}
       OVMS_TIMEOUT: ${OVMS_TIMEOUT:-120}
       
       # Semantic service
@@ -160,6 +162,8 @@ services:
         condition: service_healthy
       semantic-service:
         condition: service_healthy
+      frame-selector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -186,11 +190,11 @@ services:
         - no_proxy=${NO_PROXY}
     container_name: oa_frame_selector
     healthcheck:
-      test: ["CMD-SHELL", "kill -0 1 2>/dev/null"]
+      test: ["CMD-SHELL", "test -f /tmp/ready"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 15s
+      retries: 12
+      start_period: 30s
     volumes:
       - ./config:/config:ro
       - ./model:/app/models
@@ -217,8 +221,6 @@ services:
       no_proxy: "localhost,127.0.0.1,order-accuracy,oa_service,minio,ovms-vlm,host.docker.internal"
     depends_on:
       minio:
-        condition: service_healthy
-      order-accuracy:
         condition: service_healthy
     networks:
       - order-accuracy-net
@@ -271,6 +273,8 @@ services:
       # OVMS settings (when VLM_BACKEND=ovms)
       - OVMS_ENDPOINT=http://ovms-vlm:8000
       - OVMS_MODEL_NAME=${OVMS_MODEL_NAME:-Qwen/Qwen2.5-VL-7B-Instruct}
+      - VLM_PRECISION=${VLM_PRECISION:-int8}
+      - VLM_DEVICE=${VLM_DEVICE:-GPU}
       - OVMS_TIMEOUT=${OVMS_TIMEOUT:-60}
       # OpenVINO settings (when VLM_BACKEND=openvino)
       - OPENVINO_MODEL_PATH=${OPENVINO_MODEL_PATH:-/models/Qwen2.5-VL-7B-Instruct}

--- a/take-away/frame-selector-service/app/frame_selector.py
+++ b/take-away/frame-selector-service/app/frame_selector.py
@@ -1461,6 +1461,7 @@ if __name__ == "__main__":
     def cleanup():
         """Cleanup function called on exit."""
         logger.info("Cleaning up resources...")
+        Path("/tmp/ready").unlink(missing_ok=True)
         shutdown_all_station_queues()
         if USE_RABBITMQ and _producer:
             _producer.close()
@@ -1479,6 +1480,10 @@ if __name__ == "__main__":
     logger.info(f"Per-station VLM queue: {'ENABLED' if USE_STATION_QUEUE else 'DISABLED'}")
     logger.info("Watching for frames in MinIO...")
     logger.info("=" * 60)
+
+    # Signal readiness for Docker health check
+    Path("/tmp/ready").touch()
+    logger.info("Readiness signal written to /tmp/ready")
 
     poll_count = 0
     while not _shutdown_requested:

--- a/take-away/frame-selector-service/app/requirements.txt
+++ b/take-away/frame-selector-service/app/requirements.txt
@@ -5,3 +5,4 @@ ultralytics==8.3.0
 requests
 pyyaml
 openvino==2024.6.0
+nncf[torch]==2.14.0

--- a/take-away/src/core/pipeline_runner.py
+++ b/take-away/src/core/pipeline_runner.py
@@ -56,6 +56,9 @@ def run_pipeline(source_type: str, source: str):
     # Explicitly pass environment to ensure PYTHONPATH is set for gvapython
     env = os.environ.copy()
     
+    # Propagate source type so frame_pipeline can skip 2PC for file uploads
+    env['SOURCE_TYPE'] = source_type
+    
     # Ensure app directory is in PYTHONPATH for gvapython to find frame_pipeline
     pythonpath = env.get('PYTHONPATH', '')
     

--- a/take-away/src/frame_pipeline.py
+++ b/take-away/src/frame_pipeline.py
@@ -195,7 +195,14 @@ _ocr_warmed_up: bool = False
 # Fault-tolerant: idempotent signals, timeout handling, retry on restart.
 # ==========================================================
 
-_commit_received: bool = False
+# For file uploads, skip 2PC entirely — no RTSP streamer to synchronize with
+_source_type = os.environ.get('SOURCE_TYPE', 'rtsp')
+# 2PC is only needed when the RTSP streamer *service* orchestrates startup
+# (SERVICE_MODE=parallel).  For any user-initiated source — file upload OR
+# manual RTSP URL via Gradio UI — the stream is already available.
+_service_mode = os.environ.get('SERVICE_MODE', 'single')
+_need_2pc = (_service_mode == 'parallel')
+_commit_received: bool = (not _need_2pc)
 _prepare_signaled: bool = False
 
 # 2PC timeout configuration
@@ -414,19 +421,25 @@ def _do_ocr_warmup():
     log(f"[OCR-WARMUP] [{ts()}] OCR warmup complete")
     
     # ========== TWO-PHASE COMMIT: PREPARE + WAIT FOR COMMIT ==========
-    # Phase 1: Signal PREPARE - we're ready to consume frames
-    _signal_prepare()
-    
-    # Also signal legacy ocr_ready for backward compatibility with RTSP streamer
-    _signal_ocr_ready()
-    
-    # Phase 2: Wait for COMMIT - RTSP streamer will signal when stream is ready
-    if _wait_for_commit():
-        log(f"[2PC-SUCCESS] [{ts()}] Synchronization complete - ready to process frames!")
+    # 2PC is only needed in parallel mode where the RTSP streamer service
+    # orchestrates stream startup.  For user-initiated sources (file upload
+    # or manual RTSP URL via Gradio UI) the source is already available.
+    if not _need_2pc:
+        log(f"[2PC-SKIP] [{ts()}] Skipping 2PC sync (service_mode={_service_mode}, source={_source_type})")
     else:
-        # Timeout - proceed anyway but log warning
-        log(f"[2PC-WARNING] [{ts()}] COMMIT not received - proceeding without sync")
-        log(f"[2PC-WARNING] [{ts()}] First order may be missed if RTSP not ready")
+        # Phase 1: Signal PREPARE - we're ready to consume frames
+        _signal_prepare()
+        
+        # Also signal legacy ocr_ready for backward compatibility with RTSP streamer
+        _signal_ocr_ready()
+        
+        # Phase 2: Wait for COMMIT - RTSP streamer will signal when stream is ready
+        if _wait_for_commit():
+            log(f"[2PC-SUCCESS] [{ts()}] Synchronization complete - ready to process frames!")
+        else:
+            # Timeout - proceed anyway but log warning
+            log(f"[2PC-WARNING] [{ts()}] COMMIT not received - proceeding without sync")
+            log(f"[2PC-WARNING] [{ts()}] First order may be missed if RTSP not ready")
     # ========== END TWO-PHASE COMMIT ==========
 
 


### PR DESCRIPTION
…for uploads

Dine-in:
- Fix PermissionError on /app/results via entrypoint.sh with gosu
- Fix 404 VLM endpoint (model name mismatch)
- Add VLM_PRECISION, VLM_DEVICE env vars to .env, compose, config.py
- Remove hardcoded model defaults, read all from env

Take-away:
- Add VLM_PRECISION, VLM_DEVICE env vars to .env.example and compose
- Add nncf to frame-selector requirements (INT8 YOLO quantization)
- Add /tmp/ready healthcheck signal to frame-selector
- Fix startup order: frame-selector healthy before order-accuracy
- Skip 2PC sync for user-initiated sources (file upload + RTSP from UI)
- Only enable 2PC in parallel mode (RTSP streamer service)