### PR TITLE
[DOCS] Deprecation notice for Take-Away and Dine-In docs here

### DIFF
--- a/dine-in/docs/README.md
+++ b/dine-in/docs/README.md
@@ -1,0 +1,6 @@
+# Dine-In documentation has been moved
+
+The docs available here are no longer maintained. The new documentation is in
+[the Retail documentation repository](https://github.com/intel-retail/documentation/tree/main/docs/user-guide/order-accuracy/dine-in).
+
+Alternatively, you can view the built documentation at [the OEP documentation site](https://docs.openedgeplatform.intel.com/dev/edge-ai-suites/ai-suite-retail/order-accuracy/dine-in/index.html).

--- a/take-away/docs/README.md
+++ b/take-away/docs/README.md
@@ -1,0 +1,6 @@
+# Take-Away documentation has been moved
+
+The docs available here are no longer maintained. The new documentation is in
+[the Retail documentation repository](https://github.com/intel-retail/documentation/tree/main/docs/user-guide/order-accuracy/take-away).
+
+Alternatively, you can view the built documentation at [the OEP documentation site](https://docs.openedgeplatform.intel.com/dev/edge-ai-suites/ai-suite-retail/order-accuracy/take-away/index.html).


### PR DESCRIPTION
Adds two README files (one for the Dine-In and one for the Take-Away sample) to notify users of the new documentation location (with a reference to the GH docs at `intel-retail/documentation` and the OEP docs website).