### PR TITLE
fix: resolve IndentationError in frame_selector.py (ITEP-92346)

### DIFF
--- a/take-away/frame-selector-service/app/frame_selector.py
+++ b/take-away/frame-selector-service/app/frame_selector.py
@@ -711,7 +711,6 @@ _yolo_device = "cpu"
 # Intercept compile_model() before YOLO loads to pin the device.
 _ov_device = _target_device  # e.g. "CPU" or "GPU"
 try:
-try:
     import openvino as _ov
 except ImportError:
     import openvino.runtime as _ov


### PR DESCRIPTION
Remove duplicate stray 'try:' statement at line 713 that caused IndentationError: expected an indented block after 'try' statement, making oa_frame_selector container exit with code 1.