### PR TITLE
[DOCS] Reorganize info in main/DI/TA READMEs vs docs, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,243 +1,111 @@
 # Order Accuracy
 
-**AI-Powered Order Validation Platform for Quick Service Restaurants**
-
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://python.org)
 [![Docker](https://img.shields.io/badge/Docker-24.0%2B-blue.svg)](https://docker.com)
 [![OpenVINO](https://img.shields.io/badge/OpenVINO-2026.0-blue.svg)](https://docs.openvino.ai)
 
----
+A suite of Intel® edge AI applications for real-time order validation in Quick Service Restaurant (QSR)
+environments, powered by Vision Language Models (VLM) and Intel® OpenVINO™ inference.
 
-## Overview
+Order Accuracy automatically detects items in food trays, bags, or containers, compares them
+against expected order data, and identifies discrepancies before orders reach customers.
 
-Order Accuracy is an enterprise AI vision platform that validates food orders in real-time using Vision Language Models (VLM). The platform automatically detects items in food trays, bags, or containers, compares them against expected order data, and identifies discrepancies before orders reach customers.
-
-### Platform Applications
+## Platform Applications
 
 The platform provides two specialized applications optimized for different restaurant scenarios:
 
-| Application | Use Case | Input Type |
-|-------------|----------|------------|
-| **[Dine-In](#dine-in-order-accuracy)** | Restaurant table service validation | Static images |
-| **[Take-Away](#take-away-order-accuracy)** | Drive-through and counter service | Video streams (RTSP) |
+| Application                                | Use Case                            |
+| ------------------------------------------ | ----------------------------------- |
+| **[Dine-In](#dine-in-order-accuracy)**     | Restaurant table service validation |
+| **[Take-Away](#take-away-order-accuracy)** | Drive-through and counter service   |
+
+### Choosing the Right Application
+
+| Criteria             | Dine-In             | Take-Away              |
+| -------------------- | ------------------- | ---------------------- |
+| **Input Type**       | Static images       | Video streams (RTSP)   |
+| **Throughput**       | Low-medium          | High (parallel)        |
+| **Latency Priority** | Accuracy over speed | Speed and accuracy     |
+| **Camera Setup**     | Fixed position      | Multi-station          |
+| **Typical Use**      | Table service       | Drive-through, counter |
+| **Processing**       | Single request      | Batch processing       |
 
 ---
 
-## Architecture
+### Dine-In Order Accuracy
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                         ORDER ACCURACY PLATFORM                                  │
-│                                                                                  │
-│  ┌──────────────────────────────┐    ┌──────────────────────────────┐          │
-│  │        DINE-IN               │    │        TAKE-AWAY             │          │
-│  │   (Image-Based Validation)   │    │  (Video Stream Validation)   │          │
-│  │                              │    │                              │          │
-│  │  • Single image capture      │    │  • Real-time RTSP streams    │          │
-│  │  • Tray/table validation     │    │  • Multi-station parallel    │          │
-│  │  • REST API integration      │    │  • Frame selection (YOLO)    │          │
-│  │  • Gradio web interface      │    │  • VLM request batching      │          │
-│  └──────────────┬───────────────┘    └──────────────┬───────────────┘          │
-│                 │                                   │                           │
-│                 └─────────────┬─────────────────────┘                           │
-│                               │                                                  │
-│                               ▼                                                  │
-│  ┌──────────────────────────────────────────────────────────────────────────┐  │
-│  │                        SHARED PLATFORM SERVICES                          │  │
-│  │                                                                          │  │
-│  │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌──────────┐ │  │
-│  │  │  OVMS VLM   │    │  Semantic   │    │   MinIO     │    │  Gradio  │ │  │
-│  │  │ (Qwen2.5-VL)│    │  Service    │    │  Storage    │    │    UI    │ │  │
-│  │  │   :8001     │    │   :8080     │    │   :9000     │    │  :7860   │ │  │
-│  │  └─────────────┘    └─────────────┘    └─────────────┘    └──────────┘ │  │
-│  └──────────────────────────────────────────────────────────────────────────┘  │
-│                                                                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
-```
+Image-based order validation for full-service restaurant expo operations. Staff
+place a plate or tray in the validation station and trigger a check via the
+Gradio UI or REST API. The system analyzes plate contents with a pre-trained
+Qwen2.5-VL model and reconciles detected items against the order manifest —
+no model fine-tuning required.
 
----
+**Best for:** table service, fixed-position cameras, accuracy-prioritized
+single-image validation.
 
-## Dine-In Order Accuracy
+For full details see the [Dine-In User Guide](./docs/user-guide/dine-in/index.md).
+Alternatively, see the [Dine-In README](./dine-in/README.md) for a quick overview of the application.
 
-**Image-based order validation for restaurant dining applications**
+### Take-Away Order Accuracy
 
-Optimized for validating food trays at serving stations before delivery to tables. Uses single image capture and VLM analysis for fast, accurate item detection.
+Real-time video stream validation for drive-through and counter service. The
+service ingests RTSP streams from multiple stations, selects relevant frames
+with a YOLO model, batches VLM requests, and validates orders in parallel
+across up to 8 workers — with circuit-breaker fault tolerance and automatic
+recovery for high-throughput deployments.
 
-### Key Features
+**Best for:** drive-through and counter service, multi-station camera setups,
+speed-and-accuracy continuous validation.
 
-- Single image capture and analysis
-- Food tray/plate item detection
-- REST API for POS integration
-- Gradio web interface for manual validation
-- Hybrid semantic matching
-
-### Quick Start
-
-```bash
-# 1. Setup OVMS Model (first time only - takes 30-60 min)
-cd ovms-service
-./setup_models.sh
-
-# 2. Build and start dine-in
-cd ../dine-in
-make build
-make up
-# Access UI at http://localhost:7861
-```
-
-> **Note:** The OVMS model setup only needs to be done once. Model files are shared between dine-in and take-away applications.
+For full details see the [Take-Away User Guide](./docs/user-guide/take-away/index.md).
+Alternatively, see the [Take-Away README](./take-away/README.md) for a quick overview of the application.
 
 ### Documentation
 
-| Document | Description |
-|----------|-------------|
-| [Getting Started](./docs/user-guide/dine-in/get-started.md) | Installation guide |
-| [System Requirements](./docs/user-guide/dine-in/get-started/system-requirements.md) | Hardware/software requirements |
-| [System Architecture](./docs/user-guide/dine-in/how-it-works.md) | Architecture and design |
-| [How to Use](./docs/user-guide/dine-in/how-to-use.md) | Usage instructions |
-| [Build from Source](./docs/user-guide/dine-in/get-started/build-from-source.md) | Build instructions |
-| [API Reference](./docs/user-guide/dine-in/api-reference.md) | REST API documentation |
-| [Release Notes](./docs/user-guide/dine-in/release-notes.md) | Version history |
-
-📖 **Full Documentation**: [dine-in/README.md](dine-in/README.md)
+| Dine-In                                                         | Take-Away                                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Get Started](./docs/user-guide/dine-in/get-started.md)         | [Get Started](./docs/user-guide/take-away/get-started.md)         |
+| [How It Works](./docs/user-guide/dine-in/how-it-works.md)       | [How It Works](./docs/user-guide/take-away/how-it-works.md)       |
+| [How to Use](./docs/user-guide/dine-in/how-to-use.md)           | [How to Use](./docs/user-guide/take-away/how-to-use.md)           |
+| [Benchmarking](./docs/user-guide/dine-in/di-benchmarking.md)    | [Benchmarking](./docs/user-guide/take-away/ta-benchmarking.md)    |
+| [API Reference](./docs/user-guide/dine-in/api-reference.md)     | [API Reference](./docs/user-guide/take-away/api-reference.md)     |
+| [Troubleshooting](./docs/user-guide/dine-in/troubleshooting.md) | [Troubleshooting](./docs/user-guide/take-away/troubleshooting.md) |
+| [Release Notes](./docs/user-guide/dine-in/release-notes.md)     | [Release Notes](./docs/user-guide/take-away/release-notes.md)     |
 
 ---
 
-## Take-Away Order Accuracy
+### Shared Platform Services
 
-**Real-time video stream validation for drive-through and counter service**
+Both applications share a common set of services:
 
-Optimized for high-throughput drive-through environments with multiple camera stations. Processes RTSP video streams in parallel using intelligent frame selection and VLM batching.
+| Service              | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| **OVMS VLM**         | OpenVINO™ Model Server running Qwen2.5-VL with an OpenAI-compatible API  |
+| **Semantic Service** | AI-powered item matching (exact → semantic → hybrid) with local fallback |
+| **MinIO Storage**    | S3-compatible object storage for frames, selections, and results         |
+| **Gradio UI**        | Web interface for manual validation and demos                            |
 
-### Key Features
+The OVMS model files are exported once and shared by both applications. See the
+[OVMS Service README](./ovms-service/README.md) for model setup and KV cache
+tuning guidance.
 
-- Real-time RTSP video stream processing
-- Multi-station parallel processing (up to 8 workers)
-- GStreamer-based video pipeline
-- YOLO-powered frame selection
-- VLM request batching for throughput
-- Circuit breaker and auto-recovery
+## Get Started
 
-### Service Modes
+**Choose an application** and follow its Get Started guide:
 
-| Mode | Description | Use Case |
-|------|-------------|----------|
-| **Single** | Single worker, Gradio UI | Development, testing |
-| **Parallel** | Multi-worker, VLM scheduler | Production deployment |
+- [Dine-In — Get Started](./docs/user-guide/dine-in/get-started.md)
+- [Take-Away — Get Started](./docs/user-guide/take-away/get-started.md)
 
-### Quick Start
+For hardware and software prerequisites, see the system requirements for the
+application you plan to deploy:
 
-```bash
-cd take-away
-
-# Single worker mode (development)
-make build
-make up
-
-# Parallel mode (production)
-make build
-make up-parallel WORKERS=4
-
-# Access UI at http://localhost:7860
-```
-
-### Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Getting Started](./docs/user-guide/take-away/get-started.md) | Installation guide |
-| [System Requirements](./docs/user-guide/take-away/get-started/system-requirements.md) | Hardware/software requirements |
-| [System Architecture](./docs/user-guide/take-away/how-it-works.md) | Architecture and design |
-| [How to Use](./docs/user-guide/take-away/how-to-use.md) | Usage instructions |
-| [Build from Source](./docs/user-guide/take-away/get-started/build-from-source.md) | Build instructions |
-| [API Reference](./docs/user-guide/take-away/api-reference.md) | REST API documentation |
-| [Benchmarking Guide](./docs/user-guide/take-away/ta-benchmarking.md) | Performance testing |
-| [Release Notes](./docs/user-guide/take-away/release-notes.md) | Version history |
-
-📖 **Full Documentation**: [take-away/README.md](take-away/README.md)
-
----
-
-## Choosing the Right Application
-
-| Criteria | Dine-In | Take-Away |
-|----------|---------|-----------|
-| **Input Type** | Static images | Video streams (RTSP) |
-| **Throughput** | Low-medium | High (parallel) |
-| **Latency Priority** | Accuracy over speed | Speed and accuracy |
-| **Camera Setup** | Fixed position | Multi-station |
-| **Typical Use** | Table service | Drive-through, counter |
-| **Processing** | Single request | Batch processing |
-
-### Recommendation
-
-- **Choose Dine-In** if you need to validate orders from captured images at serving stations
-- **Choose Take-Away** if you need real-time validation from continuous video streams
-
----
-
-## Shared Platform Components
-
-### VLM Backend (OVMS)
-
-Both applications use OpenVINO Model Server with Qwen2.5-VL for vision-language inference:
-
-```bash
-# OVMS provides OpenAI-compatible API
-curl http://localhost:8001/v3/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "Qwen/Qwen2.5-VL-7B-Instruct-ov-int8",
-    "messages": [...]
-  }'
-```
-
-### Semantic Comparison Service
-
-AI-powered semantic matching microservice for intelligent item comparison:
-
-- **Matching Strategies**: Exact → Semantic → Hybrid
-- **Example**: Matches "green apple" ↔ "apple" using semantic reasoning
-- **Fallback**: Automatic fallback to local matching if service unavailable
-
-### MinIO Storage
-
-S3-compatible object storage for frames and results:
-
-- **frames bucket**: Raw captured frames
-- **selected bucket**: YOLO-selected frames
-- **results bucket**: Validation results
-
-Access MinIO Console: http://localhost:9001 (minioadmin/minioadmin)
-
----
-
-## System Requirements
-
-### Minimum Configuration
-
-| Component | Specification |
-|-----------|---------------|
-| CPU | Intel Xeon 8+ cores |
-| RAM | 64 GB (required for first-time model export); 16 GB for inference only |
-| GPU | Intel Arc A770 16 GB (8 GB requires `CACHE_SIZE=2` or lower) |
-| Storage | 50 GB SSD |
-| Docker | 24.0+ with Compose V2 |
-
-### Recommended Configuration
-
-| Component | Specification |
-|-----------|---------------|
-| CPU | Intel Xeon 16+ cores |
-| RAM | 64 GB |
-| GPU | NVIDIA RTX 3080+ / Intel Data Center GPU |
-| Storage | 200 GB NVMe SSD |
-| Network | 10 Gbps (for Take-Away RTSP) |
+- [Dine-In — System Requirements](./docs/user-guide/dine-in/get-started/system-requirements.md)
+- [Take-Away — System Requirements](./docs/user-guide/take-away/get-started/system-requirements.md)
 
 > **⚠ Model Export RAM Requirement:** `setup_models.sh` performs INT8 quantization of Qwen2.5-VL-7B, which temporarily requires up to 40 GB of system RAM (FP16 model ~15 GB + INT8 compressed ~8 GB + calibration buffers ~8–15 GB). On platforms with 32 GB RAM (e.g. Wildcat Lake, Meteor Lake), the export OOMs and writes partial, corrupt XML files, causing the `oa_ovms_vlm` container to fail at startup with "Unable to read the model" errors. Always run `setup_models.sh` on a system with at least 48 GB RAM (64 GB recommended). The exported model files can then be copied to lower-memory systems for inference-only deployments.
 >
-> **ℹ OVMS KV Cache (`cache_size`):** The default `CACHE_SIZE=4` reserves 4 GB of VRAM for the KV cache. The INT8 model itself uses ~8 GB VRAM, so total VRAM ≈ 12 GB (fits in Intel Arc A770 16 GB). On **integrated GPU** platforms (Wildcat Lake, Meteor Lake), the KV cache is allocated from **system RAM** — on a 32 GB system this can exhaust all available memory. Use a smaller value (`CACHE_SIZE=2`) on iGPU platforms. Set `export CACHE_SIZE=<N>` before running `setup_models.sh`, or edit `graph.pbtxt` directly after export. See [OVMS Service README — Tuning the KV Cache Size](ovms-service/README.md#tuning-the-kv-cache-size) for a full sizing guide and per-platform recommendations.
+> **ℹ OVMS KV Cache (`cache_size`):** The default `CACHE_SIZE=4` reserves 4 GB of VRAM for the KV cache. The INT8 model itself uses ~8 GB VRAM, so total VRAM ≈ 12 GB (fits in Intel Arc A770 16 GB). On **integrated GPU** platforms (Wildcat Lake, Meteor Lake), the KV cache is allocated from **system RAM** — on a 32 GB system this can exhaust all available memory. Use a smaller value (`CACHE_SIZE=2`) on iGPU platforms. Set `export CACHE_SIZE=<N>` before running `setup_models.sh`, or edit `graph.pbtxt` directly after export. See [OVMS Service README — Tuning the KV Cache Size](./ovms-service/README.md#tuning-the-kv-cache-size) for a full sizing guide and per-platform recommendations.
 
 ---
 
@@ -247,75 +115,26 @@ Access MinIO Console: http://localhost:9001 (minioadmin/minioadmin)
 order-accuracy/
 ├── dine-in/                     # Dine-In application
 │   ├── src/                     # Application source code
-│   ├── docs/                    # Documentation
 │   ├── docker-compose.yaml      # Service orchestration
 │   ├── Makefile                 # Build automation
 │   └── README.md                # Dine-In documentation
+│
+├── docs/user-guide
+│   ├── dine-in/                 # Dine-In user guide
+│   └── take-away/               # Take-Away user guide
 │
 ├── take-away/                   # Take-Away application
 │   ├── src/                     # Application source code
 │   ├── frame-selector-service/  # YOLO frame selection
 │   ├── gradio-ui/               # Web interface
-│   ├── docs/                    # Documentation
 │   ├── docker-compose.yaml      # Service orchestration
 │   ├── Makefile                 # Build automation
 │   └── README.md                # Take-Away documentation
 │
 ├── ovms-service/                # Shared OVMS configuration
 ├── performance-tools/           # Benchmarking scripts
-├── config/                      # Shared configuration
 └── README.md                    # This file
 ```
-
----
-
-## Quick Reference
-
-### Dine-In Commands
-
-```bash
-cd dine-in
-make build                  # Build Docker images
-make up                     # Start services
-make down                   # Stop services
-make logs                   # View logs
-make update-submodules      # Initialize performance-tools (required before benchmarking)
-make benchmark              # Run benchmark
-make benchmark-stream-density      # Run stream density test
-make benchmark-density-results  # View density benchmark results
-```
-
-### Take-Away Commands
-
-```bash
-cd take-away
-make init-env               # Create .env from template
-make build                  # Build Docker images
-make up                     # Start (single mode)
-make down                   # Stop services
-make logs                   # View logs
-make update-submodules      # Initialize performance-tools (required before benchmarking)
-make download-sample-video  # Download sample video
-make benchmark              # Run Order Accuracy benchmark
-make benchmark-stream-density  # Stream density test (latency-based)
-make consolidate-metrics    # Consolidate benchmark metrics to CSV
-make plot-metrics           # Generate plots from benchmark metrics
-```
-
-> **Note:** Before running benchmarks, ensure a test video is present at `storage/videos/test.mp4`. Use `make download-sample-video` to fetch one.
-
----
-
-## Service Endpoints
-
-| Service | Port | URL |
-|---------|------|-----|
-| Order Accuracy API | 8000 | http://localhost:8000 |
-| OVMS VLM | 8001 | http://localhost:8001 |
-| Gradio UI | 7860 | http://localhost:7860 |
-| MinIO API | 9000 | http://localhost:9000 |
-| MinIO Console | 9001 | http://localhost:9001 |
-| Semantic Service | 8080 | http://localhost:8080 |
 
 ---
 
@@ -325,18 +144,16 @@ Copyright © 2025 Intel Corporation
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
 
----
-
 ## Support
 
 For application-specific issues, refer to the respective documentation:
 
-- **Dine-In Issues**: See [dine-in/docs/](dine-in/docs/user-guide/)
-- **Take-Away Issues**: See [take-away/docs/](take-away/docs/user-guide/)
+- **Dine-In Issues**: See [Dine-In Troubleshooting](./docs/user-guide/dine-in/troubleshooting.md)
+- **Take-Away Issues**: See [Take-Away Troubleshooting](./docs/user-guide/take-away/troubleshooting.md)
 
-For platform-wide issues or feature requests, submit an issue with:
+For platform-wide issues or feature requests, [submit an issue](https://github.com/intel-retail/order-accuracy/issues) with:
 
-1. Application name (dine-in/take-away)
+1. Application name (dine-in / take-away)
 2. Steps to reproduce
-3. Expected vs actual behavior
+3. Expected vs. actual behavior
 4. Logs (`make logs`)

--- a/dine-in/README.md
+++ b/dine-in/README.md
@@ -2,7 +2,7 @@
 
 **Image-based Order Validation for Restaurant Dining Applications**
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://python.org)
 [![Docker](https://img.shields.io/badge/Docker-24.0%2B-blue.svg)](https://docker.com)
 [![OpenVINO](https://img.shields.io/badge/OpenVINO-2026.0-blue.svg)](https://docs.openvino.ai)
@@ -14,7 +14,7 @@
 ### Prerequisites
 
 - Docker 24.0+ with Compose V2
-- Intel GPU
+- Intel GPU with drivers installed
 - 16 GB RAM minimum (64 GB recommended for production)
 - Intel Xeon or equivalent CPU
 
@@ -30,7 +30,7 @@ Before running the application, you must prepare your test data:
 
 2. **Update Orders**: Edit `configs/orders.json` with your test orders
    - Each order should have an `order_id` and list of `items`
-   - Order IDs should match your image filenames
+   - `order_id` should match your `image_id`
 
 3. **Update Inventory**: Edit `configs/inventory.json` to match your menu items
    - Define all possible food items that can appear in orders
@@ -38,7 +38,7 @@ Before running the application, you must prepare your test data:
 
 > **Note:** The `images/` folder does not contain sample images by default. You must add your own images before testing.
 
-### 1. Configure Environment
+### 1. Configure the Environment
 
 ```bash
 cd order-accuracy/dine-in
@@ -59,111 +59,60 @@ cd ../ovms-service
 cd ../dine-in
 ```
 
+> **Note:** Only needed once. Model files are shared between Dine-In and Take-Away.
+
 This step:
 
 - Downloads Qwen2.5-VL-7B-Instruct from HuggingFace (~7 GB)
-- Converts to OpenVINO INT8 format
-
-> **Note:** Only needed once. Model files are shared between dine-in and take-away.
+- Converts to OpenVINO™ INT8 format
 
 ### 3. Build and Start
 
 **Option A: Using Registry Images (default)**
+
 ```bash
 make build && make up
 ```
 
 **Option B: Build Locally from Source**
+
 ```bash
 make up REGISTRY=false
 ```
 
-| Image | Tag |
-|-------|-----|
+| Image                          | Tag        |
+| ------------------------------ | ---------- |
 | `intel/order-accuracy-dine-in` | `2026.1.0` |
 
 ### 4. Access Services
 
-| Service | URL | Purpose |
-|---------|-----|--------|
-| Gradio UI | http://localhost:7861 | Interactive order validation |
-| Order Accuracy API | http://localhost:8083 | REST API endpoints |
-| API Docs | http://localhost:8083/docs | Swagger/OpenAPI documentation |
-| OVMS VLM | http://localhost:8002 | VLM model server |
+| Service            | URL                        | Purpose                       |
+| ------------------ | -------------------------- | ----------------------------- |
+| Gradio UI          | http://localhost:7861      | Interactive order validation  |
+| Order Accuracy API | http://localhost:8083      | REST API endpoints            |
+| API Docs           | http://localhost:8083/docs | Swagger/OpenAPI documentation |
+| OVMS VLM           | http://localhost:8002      | VLM model server              |
 
 ---
 
 ## Documentation
 
-- **Overview**
-  - [System Architecture](../docs/user-guide/dine-in/how-it-works.md): Architecture, design and component details of the Dine-In application.
-  - [System Requirements](../docs/user-guide/dine-in/get-started/system-requirements.md): Hardware/software requirements and pre-deployment checklist.
+| Document                                                                               | Description                                                              |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Getting Started](../docs/user-guide/dine-in/get-started.md)                           | Installation and setup guide                                             |
+| [System Requirements](../docs/user-guide/dine-in/get-started/system-requirements.md)   | Hardware/software requirements and pre-deployment checklist              |
+| [System Architecture](../docs/user-guide/dine-in/how-it-works.md)                      | Architecture, design and component details of the Dine-In application.   |
+| [How to Use](../docs/user-guide/dine-in/how-to-use.md)                                 | Usage instructions and workflows                                         |
+| [Build from Source](../docs/user-guide/dine-in/get-started/build-from-source.md)       | Source build instructions                                                |
+| [API Reference](../docs/user-guide/dine-in/api-reference.md)                           | Complete REST API documentation                                          |
+| [Benchmarking Guide](../docs/user-guide/dine-in/di-benchmarking.md)                    | Performance testing guide                                                |
+| [Troubleshooting](../docs/user-guide/dine-in/troubleshooting.md)                       | Common issues and resolutions                                            |
+| [Release Notes](../docs/user-guide/dine-in/release-notes.md)                           | Version history and changes                                              |
 
-- **Getting Started**
-  - [Get Started](../docs/user-guide/dine-in/get-started.md): Step-by-step guide to get started with the sample application.
-  - [How to Use the Application](../docs/user-guide/dine-in/how-to-use.md): Explore the application's features and verify its functionality.
+## Support
 
-- **Deployment**
-  - [How to Build from Source](../docs/user-guide/dine-in/get-started/build-from-source.md): Instructions for building from source code.
+For issues, questions, or contributions:
 
-- **API Reference**
-  - [API Reference](../docs/user-guide/dine-in/api-reference.md): Comprehensive reference for the available REST API endpoints.
-
-- **Release Notes**
-  - [Release Notes](../docs/user-guide/dine-in/release-notes.md): Information on the latest updates, improvements, and bug fixes.
-
----
-
-## Benchmarking
-
-See [Get Started](../docs/user-guide/dine-in/get-started.md#benchmarking) for detailed benchmark configuration options.
-
-### Prerequisites
-
-Initialize the performance-tools submodule before running benchmarks:
-
-```bash
-make update-submodules
-```
-
-### Quick Test
-
-> **Prerequisite:** Services must be running. Start them first with `make up`.
-
-```bash
-make benchmark-single IMAGE_ID=MCD-1001    # Quick single image test
-```
-
-### Full Benchmark
-
-```bash
-make benchmark           # Run Order Accuracy benchmark
-```
-
-> **Note:** `make benchmark` uses Docker profiles to start worker containers. Both the `dine-in` app and `dinein-worker` services use the **same Docker image** (built from the same Dockerfile). The worker is simply the same container running `worker.py` instead of the UI.
-
-### Stream Density Test
-
-```bash
-make benchmark-density   # Find max concurrent validations
-```
-
-> **Note:** `make benchmark-density` runs a Python script locally that sends concurrent HTTP requests to the running `dine-in` API. No separate worker containers are needed for this mode.
-
-### Metrics Processing
-
-```bash
-make consolidate-metrics # Consolidate results to CSV
-make plot-metrics        # Generate visualization plots
-```
-
----
-
-## Cleanup
-
-```bash
-make down           # Stop all services
-make clean          # Stop and remove volumes
-make clean-images   # Remove dangling Docker images
-make clean-all      # Remove all unused Docker resources
-```
+1. Review the [documentation](../docs/user-guide/dine-in/troubleshooting.md) and [release notes](../docs/user-guide/dine-in/release-notes.md)
+2. Check existing [issues](https://github.com/intel-retail/order-accuracy/issues)
+3. Submit a detailed bug report or feature request. See the [Support](../README.md#support) section of the main README for guidance.

--- a/docs/user-guide/dine-in/di-benchmarking.md
+++ b/docs/user-guide/dine-in/di-benchmarking.md
@@ -1,0 +1,84 @@
+# Benchmarking Guide — Dine-In Order Accuracy
+
+This guide covers performance testing, stream density benchmarking, and metrics collection for the Dine-In Order Accuracy system.
+
+> **Note — Inference Device:** The default device is `GPU`. To switch to `CPU`, you must do **both** steps below, otherwise the model will be exported for the wrong device:
+>
+> 1. Set **both** variables in your `.env` file:
+>
+>    ```bash
+>    TARGET_DEVICE=GPU      # used by setup_models.sh and docker-compose
+>    OPENVINO_DEVICE=GPU    # used by the Makefile benchmark targets
+>    ```
+>
+> 2. Re-export the model for the new device:
+>
+>    ```bash
+>    cd ../ovms-service && ./setup_models.sh --app dine-in
+>    ```
+>
+> `TARGET_DEVICE` is what `setup_models.sh` reads to export the model in the correct format. `OPENVINO_DEVICE` is what the Makefile passes to the benchmark script. Both must match.
+
+## Prerequisites
+
+```bash
+# 1. Initialize git submodules (first time only)
+make update-submodules
+
+# 2. Start services
+make up
+```
+
+> **Important:** The `images/` folder does not contain sample images. Add your own before testing:
+>
+> 1. Place plate images in `images/` (`.jpg`, `.jpeg`, or `.png`)
+> 2. Edit `configs/orders.json` — add entries with `image_id` matching your filenames
+> 3. Edit `configs/inventory.json` — define all possible menu items
+
+## Benchmark Commands
+
+### Single Image Test
+
+```bash
+make benchmark-single IMAGE_ID=MCD-1001
+```
+
+### Full Benchmark
+
+```bash
+make benchmark
+```
+
+> **Note:** `make benchmark` uses Docker profiles to start worker containers. Both the `dine-in` app and `dinein-worker` services use the **same Docker image** (built from the same Dockerfile). The worker is simply the same container running `worker.py` instead of the UI.
+
+**Variables:**
+
+| Variable                      | Default | Description            |
+| ----------------------------- | ------- | ---------------------- |
+| `BENCHMARK_WORKERS`           | 1       | Concurrent workers     |
+| `BENCHMARK_DURATION`          | 180     | Duration (seconds)     |
+| `BENCHMARK_TARGET_LATENCY_MS` | 25000   | Latency threshold (ms) |
+| `TARGET_DEVICE`               | GPU     | Device: CPU, GPU       |
+
+### Stream Density Benchmark
+
+Finds the maximum number of concurrent image validations within the latency target:
+
+```bash
+make benchmark-stream-density
+
+# With overrides
+make benchmark-stream-density BENCHMARK_TARGET_LATENCY_MS=20000 BENCHMARK_INIT_DURATION=30
+```
+
+> **Note:** `make benchmark-density` runs a Python script locally that sends concurrent HTTP requests to the running `dine-in` API. No separate worker containers are needed for this mode.
+
+## Metrics Processing
+
+```bash
+# Consolidate metrics from multiple runs into a single CSV
+make consolidate-metrics
+
+# Generate plots from consolidated metrics
+make plot-metrics
+```

--- a/docs/user-guide/dine-in/get-started.md
+++ b/docs/user-guide/dine-in/get-started.md
@@ -2,7 +2,12 @@
 
 This guide walks you through installation, configuration, and first run of the Dine-In Order Accuracy system.
 
----
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Installation](#installation)
+3. [Verifying Installation](#verifying-installation)
+4. [First Order Validation](#first-order-validation)
 
 ## Prerequisites
 
@@ -23,13 +28,18 @@ docker --version
 docker compose version
 ```
 
----
+## Installation
 
-## Step 1: Configure Environment
+### Step 1: Clone the Repository
 
 ```bash
+git clone https://github.com/intel-retail/order-accuracy.git
 cd order-accuracy/dine-in
+```
 
+### Step 2: Configure the Environment
+
+```bash
 # Create .env from template
 make init-env
 # Edit .env if needed — defaults work for most setups
@@ -38,9 +48,9 @@ make init-env
 make update-submodules
 ```
 
-## Step 2: Setup OVMS Model (First Time Only)
+### Step 3: Setup OVMS Model (First Time Only)
 
-The setup script reads model configuration (device, precision, model name) from `dine-in/.env` (created in Step 1), so **complete Step 1 before running this step**.
+The setup script reads model configuration (device, precision, model name) from `dine-in/.env` (created in Step 2), so **complete Step 2 before running this step**.
 
 ```bash
 cd ../ovms-service
@@ -48,19 +58,27 @@ cd ../ovms-service
 cd ../dine-in
 ```
 
-> **Note:** If you previously ran setup for take-away, the model files are already shared and this step will detect them automatically — no re-download needed.
+> **Note:** Only needed once. Model files are shared between Dine-In and Take-Away.
 
-This downloads Qwen2.5-VL-7B-Instruct (~7 GB) and converts it to OpenVINO INT8 format. This is only needed once — the model files are shared with Take-Away.
+This downloads Qwen2.5-VL-7B-Instruct (~7 GB) and converts it to OpenVINO™ INT8 format. This is only needed once — the model files are shared with Take-Away.
 
-## Step 3: Prepare Test Data
+### Step 4: Prepare Test Data
 
-The `images/` folder does not contain sample images. Add your own before testing:
+Before running the application, you must prepare your test data:
 
-1. Place plate images in `images/` (`.jpg`, `.jpeg`, or `.png`)
-2. Edit `configs/orders.json` — add entries with `image_id` matching your filenames
-3. Edit `configs/inventory.json` — define all possible menu items
+1. **Add Images**: Place your food tray images in the `images/` folder
+   - Supported formats: `.jpg`, `.jpeg`, `.png`
+   - Images should clearly show the food items on the tray
 
-## Step 4: Build and Start
+2. **Update Orders**: Edit `configs/orders.json` with your test orders
+   - Each order should have an `order_id` and list of `items`
+   - `order_id` should match your `image_id`
+
+3. **Update Inventory**: Edit `configs/inventory.json` to match your menu items
+   - Define all possible food items that can appear in orders
+   - Include item names, categories, and any relevant metadata
+
+### Step 5: Build and Start
 
 ```bash
 # Pull images from registry (default)
@@ -98,7 +116,7 @@ Open `http://localhost:7861` for the Gradio UI, or `http://localhost:8083/docs` 
 
 ---
 
-## First Validation
+## First Order Validation
 
 ### Via Gradio UI
 
@@ -140,49 +158,6 @@ make benchmark-single IMAGE_ID=MCD-1001
 
 ---
 
-## Benchmarking
-
-### Single Image Test
-
-```bash
-make benchmark-single IMAGE_ID=MCD-1001
-```
-
-### Full Benchmark
-
-```bash
-make benchmark
-```
-
-Key variables:
-
-| Variable                      | Default | Description            |
-| ----------------------------- | ------- | ---------------------- |
-| `BENCHMARK_WORKERS`           | 1       | Concurrent workers     |
-| `BENCHMARK_DURATION`          | 180     | Duration (seconds)     |
-| `BENCHMARK_TARGET_LATENCY_MS` | 25000   | Latency threshold (ms) |
-| `TARGET_DEVICE`               | GPU     | Device: CPU, GPU       |
-
-### Stream Density Test
-
-Finds the maximum number of concurrent image validations within the latency target:
-
-```bash
-make benchmark-stream-density
-
-# With overrides
-make benchmark-stream-density BENCHMARK_TARGET_LATENCY_MS=20000 BENCHMARK_INIT_DURATION=30
-```
-
-### Metrics Processing
-
-```bash
-make consolidate-metrics   # Consolidate results to CSV
-make plot-metrics          # Generate visualisation plots
-```
-
----
-
 ## Changing Inference Device
 
 To switch between GPU and CPU, update `TARGET_DEVICE` in `.env` and re-run model setup:
@@ -191,36 +166,9 @@ To switch between GPU and CPU, update `TARGET_DEVICE` in `.env` and re-run model
 # In .env
 TARGET_DEVICE=CPU
 
-cd ../ovms-service && ./setup_models.sh && cd ../dine-in
+cd ../ovms-service && ./setup_models.sh --app dine-in && cd ../dine-in
 make down && make up
 ```
-
----
-
-## Troubleshooting
-
-### OVMS Not Starting
-
-```bash
-docker logs dinein_ovms_vlm
-ls -la ../ovms-service/models/
-```
-
-OVMS can take 2–5 minutes to load the model. Wait for `"Server started"` in the logs.
-
-### GPU Not Detected
-
-```bash
-sudo usermod -aG render $USER
-# Log out and back in, then restart services
-make down && make up
-```
-
-### No Scenarios in UI
-
-Ensure images are in `images/` and `configs/orders.json` has entries with matching `image_id` values (filename without extension).
-
----
 
 ## Quick Reference
 
@@ -233,18 +181,21 @@ make test-api                        # Health check
 make benchmark-single IMAGE_ID=...   # Quick test
 make benchmark                       # Full benchmark
 make benchmark-stream-density        # Stream density test
+make clean                           # Stop and remove volumes
+make clean-images                    # Remove dangling Docker images
+make clean-all                       # Remove all unused Docker resources
 make help                            # All commands
 ```
 
----
-
 ## Next Steps
 
-- [System Requirements](./get-started/system-requirements.md) - Check the requirements
+- [System Requirements](./get-started/system-requirements.md) - Check the detailed requirements
 - [Build from Source](./get-started/build-from-source.md) - Build from source
 - [How It Works](./how-it-works.md) - Learn about the architecture
 - [How to Use](./how-to-use.md) - Customize settings
+- [Benchmarking Guide](./di-benchmarking.md) - Run benchmarks
 - [API Reference](./api-reference.md) - Learn the API
+- [Troubleshooting](./troubleshooting.md) - Resolve common issues
 - [Release Notes](./release-notes.md) - Read about updates and improvements
 
 <!--hide_directive

--- a/docs/user-guide/dine-in/get-started/build-from-source.md
+++ b/docs/user-guide/dine-in/get-started/build-from-source.md
@@ -102,16 +102,4 @@ curl http://localhost:8083/health
 
 ## Troubleshooting
 
-### Build Fails (network / pip)
-
-```bash
-docker compose build --no-cache
-```
-
-### GPU Not Detected
-
-```bash
-sudo usermod -aG render $USER
-# Log out and back in, then restart
-make down && make up
-```
+For common issues, see [Troubleshooting](../troubleshooting.md).

--- a/docs/user-guide/dine-in/how-it-works.md
+++ b/docs/user-guide/dine-in/how-it-works.md
@@ -139,7 +139,7 @@ This document provides a comprehensive technical overview of the system architec
 
 ### 1. VLM Client (`vlm_client.py`)
 
-The VLM Client handles communication with OpenVINO Model Server for visual inference.
+The VLM Client handles communication with OpenVINO™ Model Server for visual inference.
 
 **Features:**
 

--- a/docs/user-guide/dine-in/index.md
+++ b/docs/user-guide/dine-in/index.md
@@ -26,8 +26,6 @@ In a full-service restaurant:
 5. System compares detected items against the order manifest
 6. Staff receives immediate feedback on order accuracy
 
----
-
 ## Key Features
 
 | Feature                      | Description                                                                      |
@@ -40,6 +38,17 @@ In a full-service restaurant:
 | **Bounded Caching**          | LRU cache prevents memory exhaustion under load                                  |
 | **Comprehensive Metrics**    | CPU, GPU, memory utilization with token-level inference stats                    |
 
+## Next Steps
+
+- [System Requirements](./get-started/system-requirements.md) - Check the detailed requirements
+- [Installation Guide](./get-started.md) - Step-by-step installation instructions
+- [How It Works](./how-it-works.md) - Learn about the architecture
+- [How To Use](./how-to-use.md) - Learn how to operate the system
+- [Benchmarking Guide](./di-benchmarking.md) - Run benchmarks
+- [API Reference](./api-reference.md) - Learn the API
+- [Troubleshooting](./troubleshooting.md) - Resolve common issues
+- [Release Notes](./release-notes.md) - Read about updates and improvements
+
 <!--hide_directive
 :::{toctree}
 :hidden:
@@ -47,7 +56,9 @@ In a full-service restaurant:
 ./get-started.md
 ./how-it-works.md
 How To Use <./how-to-use.md>
+Benchmarking <./di-benchmarking.md>
 API Reference <./api-reference.md>
+Troubleshooting <./troubleshooting.md>
 Release Notes <./release-notes.md>
 
 :::

--- a/docs/user-guide/dine-in/troubleshooting.md
+++ b/docs/user-guide/dine-in/troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+This article covers common issues and how to resolve them. If you encounter a problem not
+listed here, see [Order Accuracy Issues](https://github.com/intel-retail/order-accuracy/issues).
+
+## Build Fails (network / pip)
+
+```bash
+docker compose build --no-cache
+```
+
+## OVMS Not Starting
+
+```bash
+# Check logs
+docker logs dinein_ovms_vlm
+
+# Verify model files exist
+ls -la ../ovms-service/models/
+```
+
+OVMS can take 2–5 minutes to load the model. Wait for `"Server started"` in the logs.
+
+## GPU Not Detected
+
+```bash
+sudo usermod -aG render $USER
+# Log out and log back in, then restart services
+make down && make up
+```
+
+## No Scenarios in UI
+
+Ensure images are in `images/` and `configs/orders.json` has entries with matching `image_id`
+values (filename without extension). See [Step 4: Prepare Test Data](./get-started.md#step-4-prepare-test-data) for details.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -109,7 +109,7 @@ Optimized for high-throughput drive-through environments with multiple camera st
 
 ### VLM Backend (OVMS)
 
-Both applications use OpenVINO Model Server with Qwen2.5-VL for vision-language inference.
+Both applications use OpenVINO™ Model Server with Qwen2.5-VL for vision-language inference.
 
 ### Semantic Comparison Service
 

--- a/docs/user-guide/oa-get-started.md
+++ b/docs/user-guide/oa-get-started.md
@@ -45,7 +45,7 @@
 
    ```bash
    cd ../ovms-service
-   ./setup_models.sh
+   ./setup_models.sh -app dine-in
    cd ../dine-in
    ```
 
@@ -93,7 +93,7 @@
 
    ```bash
    cd ../ovms-service
-   ./setup_models.sh
+   ./setup_models.sh -app take-away
    cd ../take-away
    ```
 
@@ -193,7 +193,7 @@ make down-volumes
 
 | Configuration      | Command                     | Description                |
 | ------------------ | --------------------------- | -------------------------- |
-| **Start Services** | `make up`                   | Start all dine-in services |
+| **Start Services** | `make up`                   | Start all Dine-In services |
 | **Build Locally**  | `make build REGISTRY=false` | Build images from source   |
 | **View Logs**      | `make logs`                 | View service logs          |
 | **Stop Services**  | `make down`                 | Stop all containers        |
@@ -209,7 +209,7 @@ make down-volumes
 | **Build Locally** | `make build REGISTRY=false`  | Build images from source                   |
 | **View Logs**     | `make logs`                  | View service logs                          |
 
-> **Note**: **Single Mode** is best for development and testing. **Parallel Mode** is recommended for production with multiple camera stations.
+> **Note:** **Single Mode** is best for development and testing. **Parallel Mode** is recommended for production with multiple camera stations.
 
 <!--hide_directive:::
 ::::hide_directive-->

--- a/docs/user-guide/oa-how-it-works.md
+++ b/docs/user-guide/oa-how-it-works.md
@@ -105,7 +105,7 @@ flowchart TB
 
 #### 1. VLM Backend (OVMS)
 
-OpenVINO Model Server hosting Qwen2.5-VL-7B for vision-language inference.
+OpenVINO™ Model Server hosting Qwen2.5-VL-7B for vision-language inference.
 
 **Features:**
 

--- a/docs/user-guide/take-away/get-started.md
+++ b/docs/user-guide/take-away/get-started.md
@@ -2,8 +2,6 @@
 
 This guide walks you through the installation, configuration, and first-run of the Take-Away Order Accuracy system.
 
----
-
 ## Table of Contents
 
 1. [Prerequisites](#prerequisites)
@@ -12,9 +10,6 @@ This guide walks you through the installation, configuration, and first-run of t
 4. [Starting the Services](#starting-the-services)
 5. [Verifying Installation](#verifying-installation)
 6. [First Order Validation](#first-order-validation)
-7. [Troubleshooting](#troubleshooting)
-
----
 
 ## Prerequisites
 
@@ -53,8 +48,6 @@ docker --version          # Docker version 24.0.x or higher
 docker compose version    # Docker Compose version v2.x.x
 ```
 
----
-
 ## Installation
 
 ### Step 1: Clone the Repository
@@ -64,39 +57,38 @@ git clone https://github.com/intel-retail/order-accuracy.git
 cd order-accuracy/take-away
 ```
 
-### Step 2: Initialize Git Submodules
+### Step 2: Configure the Environment
 
 ```bash
-make update-submodules
-```
-
-### Step 3: Create Environment File
-
-```bash
+# Create .env from template
 make init-env
+# Edit .env if needed — defaults work for most setups
+
+# Initialize git submodules (for benchmark tools)
+make update-submodules
 ```
 
 Edit the generated `.env` file as needed. See [Configuration](#configuration) below.
 
-### Step 4: Setup OVMS Models (First Time Only)
+### Step 3: Setup OVMS Model (First Time Only)
 
 Set `TARGET_DEVICE` in your `.env` **before** running this step. The script reads that value to export the model in the correct format for the target device.
 
 ```bash
 cd ../ovms-service
-./setup_models.sh
+./setup_models.sh --app take-away    # Downloads and exports model (~30-60 min first time)
 cd ../take-away
 ```
 
 This downloads and exports:
 
-- Qwen2.5-VL-7B-Instruct (OpenVINO format)
-- YOLOv11 model (INT8 OpenVINO)
+- Qwen2.5-VL-7B-Instruct (OpenVINO™ format)
+- YOLOv11 model (INT8 OpenVINO™)
 - EasyOCR detection and recognition models
 
 > **Note:** Re-run this step any time you change `TARGET_DEVICE` in `.env`.
 
-### Step 5: Build and Start
+### Step 4: Build and Start
 
 ```bash
 # Pull images from registry (default)
@@ -144,7 +136,7 @@ MINIO_ROOT_PASSWORD=<your-minio-password>
 MINIO_ENDPOINT=minio:9000
 ```
 
-> **Changing the inference device:** Set both `TARGET_DEVICE` and `OPENVINO_DEVICE` to the same value (`GPU` or `CPU`), then re-run `./setup_models.sh` to re-export the model for that device.
+> **Changing the inference device:** Set both `TARGET_DEVICE` and `OPENVINO_DEVICE` to the same value (`GPU` or `CPU`), then re-run `./setup_models.sh --app take-away` to re-export the model for that device.
 
 ### Validate Configuration
 
@@ -253,56 +245,6 @@ make benchmark
 
 ---
 
-## Troubleshooting
-
-### OVMS Not Starting
-
-```bash
-# Check logs
-docker logs oa_ovms_vlm
-
-# Verify model files exist
-ls -la ../ovms-service/models/
-```
-
-### Connection Refused to OVMS (port 8001)
-
-OVMS can take 2–5 minutes to load the model. Wait and check:
-
-```bash
-docker logs -f oa_ovms_vlm | grep "Serving"
-```
-
-### MinIO Bucket Errors
-
-```bash
-# Recreate MinIO with fresh volumes
-make down
-docker volume rm take-away_minio_data
-make up
-```
-
-### GPU Not Detected
-
-```bash
-sudo usermod -aG render $USER
-# Log out and log back in, then restart services
-make down && make up
-```
-
-### GPU OOM / Out of Memory
-
-```bash
-# Switch to CPU: set both in .env, then re-export model
-TARGET_DEVICE=CPU
-OPENVINO_DEVICE=CPU
-# Then:
-cd ../ovms-service && ./setup_models.sh
-cd ../take-away && make down && make up
-```
-
----
-
 ## Quick Reference
 
 ```bash
@@ -327,6 +269,7 @@ make benchmark-stream-density  # Run stream density benchmark
 - [How to Use](./how-to-use.md) - Customize settings
 - [Benchmarking Guide](./ta-benchmarking.md) - Run benchmarks
 - [API Reference](./api-reference.md) - Learn the API
+- [Troubleshooting](./troubleshooting.md) - Resolve common issues
 - [Release Notes](./release-notes.md) - Read about updates and improvements
 
 <!--hide_directive

--- a/docs/user-guide/take-away/get-started/build-from-source.md
+++ b/docs/user-guide/take-away/get-started/build-from-source.md
@@ -2,8 +2,6 @@
 
 This guide covers building Docker images locally instead of pulling them from the registry.
 
----
-
 ## Prerequisites
 
 - Docker 24.0+ and Docker Compose V2+
@@ -13,8 +11,6 @@ This guide covers building Docker images locally instead of pulling them from th
 docker --version
 docker compose version
 ```
-
----
 
 ## Repository Structure
 
@@ -31,8 +27,6 @@ take-away/
 ├── Makefile
 └── requirements.txt
 ```
-
----
 
 ## Building Images
 
@@ -72,25 +66,21 @@ docker compose build rtsp-streamer
 docker compose build --no-cache
 ```
 
----
-
 ## Model Preparation
 
 Before starting services, download and export models:
 
 ```bash
 cd ../ovms-service
-./setup_models.sh
+./setup_models.sh --app take-away
 cd ../take-away
 ```
 
 This downloads and exports:
 
-- **Qwen2.5-VL-7B-Instruct** (OpenVINO INT8) → `ovms-service/models/`
+- **Qwen2.5-VL-7B-Instruct** (OpenVINO™ INT8) → `ovms-service/models/`
 - **EasyOCR** models → `take-away/models/easyocr/`
 - **YOLO11n** (FP32 + INT8 OpenVINO) → `take-away/models/`
-
----
 
 ## Start Services
 
@@ -105,29 +95,6 @@ make status
 make test-api
 ```
 
----
-
 ## Troubleshooting
 
-### Build Fails (network / pip)
-
-```bash
-docker compose build --no-cache
-```
-
-### Model File Not Found
-
-```bash
-# Verify models were correctly set up
-ls ../ovms-service/models/
-ls models/easyocr/
-ls models/yolo11n_int8_openvino_model/
-```
-
-### GPU Not Detected
-
-```bash
-sudo usermod -aG render $USER
-# Log out and back in, then restart services
-make down && make up
-```
+For common issues, see [Troubleshooting](../troubleshooting.md).

--- a/docs/user-guide/take-away/how-it-works.md
+++ b/docs/user-guide/take-away/how-it-works.md
@@ -31,7 +31,7 @@ flowchart TB
 | Station Workers        | GStreamer (DL Streamer), multiprocessing | RTSP video processing           |
 | VLM Scheduler          | Threading, queue batching                | Request optimization            |
 | Frame Selector         | YOLO, OpenCV                             | Optimal frame detection         |
-| OVMS VLM               | OpenVINO Model Server                    | Vision Language Model inference |
+| OVMS VLM               | OpenVINO™ Model Server                   | Vision Language Model inference |
 | Semantic Service       | FastAPI                                  | Text semantic matching          |
 | Gradio UI              | Gradio                                   | Web interface                   |
 | MinIO                  | S3-compatible storage                    | Frame and result storage        |
@@ -259,7 +259,7 @@ Vision Language Model processing with inventory detection and order validation.
 
 ### 5. OVMS VLM Client (`src/core/ovms_client.py`)
 
-OpenVINO Model Server client with OpenAI-compatible API.
+OpenVINO™ Model Server client with OpenAI-compatible API.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -637,7 +637,7 @@ Scaling architecture:
 | ------------------ | ------------------------------------------------ |
 | VLM Batching       | 50-100ms time windows via VLM Scheduler          |
 | Frame Selection    | YOLO pre-filtering reduces unnecessary VLM calls |
-| INT8 Quantization  | OpenVINO INT8 model served via OVMS              |
+| INT8 Quantization  | OpenVINO™ INT8 model served via OVMS             |
 | Connection Pooling | HTTP session reuse to OVMS                       |
 
 ---

--- a/docs/user-guide/take-away/index.md
+++ b/docs/user-guide/take-away/index.md
@@ -13,6 +13,17 @@ hide_directive-->
 
 Take-Away Order Accuracy is an enterprise-grade AI vision system designed for real-time order validation in quick-service restaurant (QSR) environments. The system employs Vision Language Models (VLM) to analyze video feeds from drive-through stations, automatically identifying items in order bags and validating them against POS order data.
 
+## Next Steps
+
+- [System Requirements](./get-started/system-requirements.md) - Check the detailed requirements
+- [Installation Guide](./get-started.md) - Step-by-step installation instructions
+- [How It Works](./how-it-works.md) - Learn about the architecture
+- [How To Use](./how-to-use.md) - Learn how to operate the system
+- [Benchmarking Guide](./ta-benchmarking.md) - Run benchmarks
+- [API Reference](./api-reference.md) - Learn the API
+- [Troubleshooting](./troubleshooting.md) - Resolve common issues
+- [Release Notes](./release-notes.md) - Read about updates and improvements
+
 <!--hide_directive
 :::{toctree}
 :hidden:
@@ -22,6 +33,7 @@ Take-Away Order Accuracy is an enterprise-grade AI vision system designed for re
 How To Use <./how-to-use.md>
 Benchmarking <./ta-benchmarking.md>
 API Reference <./api-reference.md>
+Troubleshooting <./troubleshooting.md>
 Release Notes <./release-notes.md>
 
 :::

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -56,7 +56,7 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 
 - **AI-Powered Order Validation**: Real-time take-away order verification using Qwen2.5-VL-7B Vision Language Model
 - **Multi-Station Parallel Processing**: Concurrent order validation across multiple stations via RTSP streams
-- **Intelligent Frame Selection**: YOLO11-based frame selection with OpenVINO INT8 inference for optimal VLM input
+- **Intelligent Frame Selection**: YOLO11-based frame selection with OpenVINO™ INT8 inference for optimal VLM input
 - **Semantic Matching**: Hybrid exact/semantic item matching via dedicated microservice
 - **Docker Registry Support**: Pre-built images published to `intel/` Docker Hub namespace
 - **Stream Density Benchmarking**: Automated latency-based stream density testing
@@ -75,9 +75,9 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 #### Core Functionality
 
 - **Dual Service Mode**: Single worker mode for development, parallel worker mode for production
-- **VLM Integration**: Qwen2.5-VL-7B-Instruct via OpenVINO Model Server (OVMS) with GPU acceleration
+- **VLM Integration**: Qwen2.5-VL-7B-Instruct via OpenVINO™ Model Server (OVMS) with GPU acceleration
 - **Video Processing**: GStreamer-based pipeline with RTSP support and configurable FPS
-- **Frame Selection**: YOLO11 nano model with OpenVINO INT8 inference for hand/object detection and frame filtering
+- **Frame Selection**: YOLO11 nano model with OpenVINO™ INT8 inference for hand/object detection and frame filtering
 - **Semantic Matching**: Hybrid exact/semantic item matching with configurable similarity threshold
 - **EasyOCR Integration**: Order number detection from video frames
 
@@ -114,7 +114,7 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 | Component              | Image                                 | Description                                             |
 | ---------------------- | ------------------------------------- | ------------------------------------------------------- |
 | Order Accuracy Service | `intel/order-accuracy-take-away`      | Core orchestration, GStreamer pipelines, VLM scheduling |
-| Frame Selector         | `intel/order-accuracy-frame-selector` | YOLO11 OpenVINO INT8 frame selection                    |
+| Frame Selector         | `intel/order-accuracy-frame-selector` | YOLO11 OpenVINO™ INT8 frame selection                   |
 | Gradio UI              | `intel/order-accuracy-take-away-ui`   | Web interface for order validation                      |
 | RTSP Streamer          | `intel/order-accuracy-take-away-rtsp` | Video-to-RTSP stream conversion with 2PC sync           |
 | OVMS VLM               | `openvino/model_server:latest-gpu`    | Qwen2.5-VL-7B model serving                             |

--- a/docs/user-guide/take-away/ta-benchmarking.md
+++ b/docs/user-guide/take-away/ta-benchmarking.md
@@ -19,14 +19,6 @@ This guide covers performance testing, stream density benchmarking, and metrics 
 >
 > `TARGET_DEVICE` is what `setup_models.sh` reads to export the model in the correct format. `OPENVINO_DEVICE` is what the Makefile passes to the benchmark script. Both must match.
 
-> **Important:** Before running benchmarks, ensure a test video file is present at `storage/videos/test.mp4`. You can download a sample video using:
->
-> ```bash
-> make download-sample-video
-> ```
-
----
-
 ## Quick Reference
 
 ```bash
@@ -54,8 +46,6 @@ make benchmark-oa-help
 make help
 ```
 
----
-
 ## Prerequisites
 
 ```bash
@@ -66,7 +56,11 @@ make update-submodules
 make up
 ```
 
----
+> **Important:** Before running benchmarks, ensure a test video file is present at `storage/videos/test.mp4`. You can download a sample video using:
+>
+> ```bash
+> make download-sample-video
+> ```
 
 ## Benchmark Commands
 

--- a/docs/user-guide/take-away/troubleshooting.md
+++ b/docs/user-guide/take-away/troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting
+
+This article covers common issues and how to resolve them. If you encounter a problem not
+listed here, see [Order Accuracy Issues](https://github.com/intel-retail/order-accuracy/issues).
+
+## Build Fails (network / pip)
+
+```bash
+docker compose build --no-cache
+```
+
+## Model File Not Found
+
+```bash
+# Verify models were correctly set up
+ls ../ovms-service/models/
+ls models/easyocr/
+ls models/yolo11n_int8_openvino_model/
+```
+
+## OVMS Not Starting
+
+```bash
+# Check logs
+docker logs oa_ovms_vlm
+
+# Verify model files exist
+ls -la ../ovms-service/models/
+```
+
+## Connection Refused to OVMS (port 8001)
+
+OVMS can take 2–5 minutes to load the model. Wait and check:
+
+```bash
+docker logs -f oa_ovms_vlm | grep "Serving"
+```
+
+## MinIO Bucket Errors
+
+```bash
+# Recreate MinIO with fresh volumes
+make down
+docker volume rm take-away_minio_data
+make up
+```
+
+## GPU Not Detected
+
+```bash
+sudo usermod -aG render $USER
+# Log out and log back in, then restart services
+make down && make up
+```
+
+## GPU Out of Memory
+
+```bash
+# Switch to CPU: set both in .env, then re-export model
+TARGET_DEVICE=CPU
+OPENVINO_DEVICE=CPU
+# Then:
+cd ../ovms-service && ./setup_models.sh --app take-away
+cd ../take-away && make down && make up
+```

--- a/ovms-service/README.md
+++ b/ovms-service/README.md
@@ -1,19 +1,19 @@
 # OVMS Service for Order Accuracy
 
-This directory contains the OpenVINO Model Server (OVMS) configuration and model export scripts for the order accuracy VLM backend.
+This directory contains the OpenVINO™ Model Server (OVMS) configuration and model export scripts for the order accuracy VLM backend.
 
 ## Directory Structure
 
 ```
 ovms-service/
-├── export_model.py          # Script to export HuggingFace models to OpenVINO format
+├── export_model.py          # Script to export HuggingFace models to OpenVINO™ format
 ├── export_requirements.txt  # Python dependencies for model export
 ├── models/                  # OVMS model repository
 │   ├── config.json          # OVMS configuration
 │   └── Qwen/                # Model directory (created after export)
 │       └── Qwen2.5-VL-7B-Instruct-ov-int8/
 │           ├── graph.pbtxt  # MediaPipe graph configuration (critical)
-│           └── openvino_*   # OpenVINO model files
+│           └── openvino_*   # OpenVINO™ model files
 └── README.md                # This file
 ```
 
@@ -35,9 +35,10 @@ bash ovms-service/setup_models.sh --app dine-in
 ```
 
 This will:
+
 - Download `export_model.py` and install its dependencies automatically
 - Download the model from HuggingFace
-- Convert to OpenVINO IR format with int8 quantization
+- Convert to OpenVINO™ IR format with int8 quantization
 - Save to `ovms-service/models/Qwen/Qwen2.5-VL-7B-Instruct/`
 - Generate `graph.pbtxt` for OVMS configuration
 
@@ -57,7 +58,7 @@ docker-compose --profile ovms up -d
 # Check OVMS health
 curl http://localhost:8002/v1/config
 
-# Check model status  
+# Check model status
 curl http://localhost:8002/v1/models
 
 # Verify model is AVAILABLE
@@ -353,4 +354,4 @@ docker logs oa_ovms_vlm 2>&1 | grep "Cache usage"
 
 - [OVMS Documentation](https://github.com/openvinotoolkit/model_server)
 - [Qwen2.5-VL Model](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct)
-- [OpenVINO GenAI](https://github.com/openvinotoolkit/openvino.genai)
+- [OpenVINO™ GenAI](https://github.com/openvinotoolkit/openvino.genai)

--- a/take-away/README.md
+++ b/take-away/README.md
@@ -69,14 +69,13 @@ cd ../ovms-service
 cd ../take-away
 ```
 
-This step:
+This downloads and exports:
 
-- Downloads Qwen2.5-VL-7B-Instruct from HuggingFace (~7 GB)
-- Converts to OpenVINO™ INT8 format
-- Downloads YOLO and EasyOCR models
-- Creates model files in `ovms-service/models/` and `take-away/models/`
+- Qwen2.5-VL-7B-Instruct (OpenVINO™ format)
+- YOLOv11 model (INT8 OpenVINO™)
+- EasyOCR detection and recognition models
 
-> **Note:** Only needed once. Model files are shared between Dine-In and Take-Away.
+> **Note:** Re-run this step any time you change `TARGET_DEVICE` in `.env`.
 
 ### 3. Build and Start
 

--- a/take-away/README.md
+++ b/take-away/README.md
@@ -2,7 +2,7 @@
 
 **Real-time Order Validation System for Quick Service Restaurants**
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://python.org)
 [![Docker](https://img.shields.io/badge/Docker-24.0%2B-blue.svg)](https://docker.com)
 [![OpenVINO](https://img.shields.io/badge/OpenVINO-2026.0-blue.svg)](https://docs.openvino.ai)
@@ -26,9 +26,9 @@ Take-Away Order Accuracy is an AI-powered vision system that validates drive-thr
 
 ### Service Modes
 
-| Mode | Description | Use Case |
-|------|-------------|----------|
-| **Single** | Single worker with Gradio UI | Development, testing, demos |
+| Mode         | Description                     | Use Case                    |
+| ------------ | ------------------------------- | --------------------------- |
+| **Single**   | Single worker with Gradio UI    | Development, testing, demos |
 | **Parallel** | Multi-worker with VLM scheduler | Production, high throughput |
 
 ---
@@ -65,18 +65,18 @@ The VLM model must be exported before running the application. The script reads 
 
 ```bash
 cd ../ovms-service
-./setup_models.sh    # Downloads and exports model (~30-60 min first time)
+./setup_models.sh --app take-away    # Downloads and exports model (~30-60 min first time)
 cd ../take-away
 ```
 
 This step:
 
 - Downloads Qwen2.5-VL-7B-Instruct from HuggingFace (~7 GB)
-- Converts to OpenVINO INT8 format
+- Converts to OpenVINO™ INT8 format
 - Downloads YOLO and EasyOCR models
 - Creates model files in `ovms-service/models/` and `take-away/models/`
 
-> **Note:** Only needed once. Model files are shared between dine-in and take-away.
+> **Note:** Only needed once. Model files are shared between Dine-In and Take-Away.
 
 ### 3. Build and Start
 
@@ -90,30 +90,29 @@ make up REGISTRY=false
 
 ### 4. Access Services
 
-| Service | URL | Purpose |
-|---------|-----|---------|
-| Gradio UI | http://localhost:7860 | Interactive order validation |
-| Order Accuracy API | http://localhost:8000 | REST API endpoints |
-| MinIO Console | http://localhost:9001 | Frame storage management |
-| OVMS VLM | http://localhost:8001 | VLM model server |
-| Semantic Service | http://localhost:8080 | Semantic matching API |
+| Service            | URL                   | Purpose                      |
+| ------------------ | --------------------- | ---------------------------- |
+| Gradio UI          | http://localhost:7860 | Interactive order validation |
+| Order Accuracy API | http://localhost:8000 | REST API endpoints           |
+| MinIO Console      | http://localhost:9001 | Frame storage management     |
+| OVMS VLM           | http://localhost:8001 | VLM model server             |
+| Semantic Service   | http://localhost:8080 | Semantic matching API        |
 
 ---
 
 ## Documentation
 
-### User Guides
-
-| Document | Description |
-|----------|-------------|
-| [Getting Started](../docs/user-guide/take-away/get-started.md) | Installation and setup guide |
-| [System Requirements](../docs/user-guide/take-away/get-started/system-requirements.md) | Hardware/software requirements and pre-deployment checklist |
-| [System Architecture](../docs/user-guide/take-away/how-it-works.md) | Architecture, design and component details of the Take-Away application. |
-| [How to Use](../docs/user-guide/take-away/how-to-use.md) | Usage instructions and workflows |
-| [Build from Source](../docs/user-guide/take-away/get-started/build-from-source.md) | Source build instructions |
-| [API Reference](../docs/user-guide/take-away/api-reference.md) | Complete REST API documentation |
-| [Benchmarking Guide](../docs/user-guide/take-away/ta-benchmarking.md) | Performance testing guide |
-| [Release Notes](../docs/user-guide/take-away/release-notes.md) | Version history and changes |
+| Document                                                                               | Description                                                              |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Getting Started](../docs/user-guide/take-away/get-started.md)                         | Installation and setup guide                                             |
+| [System Requirements](../docs/user-guide/take-away/get-started/system-requirements.md) | Hardware/software requirements and pre-deployment checklist              |
+| [System Architecture](../docs/user-guide/take-away/how-it-works.md)                    | Architecture, design and component details of the Take-Away application. |
+| [How to Use](../docs/user-guide/take-away/how-to-use.md)                               | Usage instructions and workflows                                         |
+| [Build from Source](../docs/user-guide/take-away/get-started/build-from-source.md)     | Source build instructions                                                |
+| [API Reference](../docs/user-guide/take-away/api-reference.md)                         | Complete REST API documentation                                          |
+| [Benchmarking Guide](../docs/user-guide/take-away/ta-benchmarking.md)                  | Performance testing guide                                                |
+| [Troubleshooting](../docs/user-guide/take-away/troubleshooting.md)                     | Common issues and resolutions                                            |
+| [Release Notes](../docs/user-guide/take-away/release-notes.md)                         | Version history and changes                                              |
 
 ---
 
@@ -131,7 +130,7 @@ make up REGISTRY=false
 
 Copyright © 2026 Intel Corporation
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
+Licensed under the Apache License, Version 2.0. See [LICENSE](../LICENSE) for details.
 
 ---
 
@@ -139,6 +138,6 @@ Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for detai
 
 For issues, questions, or contributions:
 
-1. Review the [documentation](docs/user-guide/)
-2. Check existing [issues](issues/)
-3. Submit a detailed bug report or feature request
+1. Review the [documentation](../docs/user-guide/take-away/troubleshooting.md) and [release notes](../docs/user-guide/take-away/release-notes.md)
+2. Check existing [issues](https://github.com/intel-retail/order-accuracy/issues)
+3. Submit a detailed bug report or feature request. See the [Support](../README.md#support) section of the main README for guidance.


### PR DESCRIPTION
This PR aims to make the main README and the README for Dine-In/Take-Away into a hub linking to the relevant docs, rather than holding all the info there.

- reorganize the main README, update and reduce the info held in Dine-In/Take-Away READMEs (moved to docs)
- add missing LICENSE (Apache 2.0)
- add a separate `troubleshooting.md` for Dine-In / Take-Away (based on already present sections in `get-started.md` and `build-from-source.md`)
- add a benchmarking guide for Dine-In (this will be likely streamlined further into against the already present overall Order Accuracy benchmarking guide, same for the current Take-Away benchmarking guide)
- add explicit target (dine-in / take-away) to the `./setup_models.sh` command
- add minor miscellaneous formatting/phrasing improvements