### PR TITLE
Update DLStreamer Docker image to 2026.2.0 RC1

### DIFF
--- a/dine-in/Dockerfile
+++ b/dine-in/Dockerfile
@@ -1,4 +1,4 @@
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 USER root
 

--- a/take-away/Dockerfile
+++ b/take-away/Dockerfile
@@ -1,4 +1,4 @@
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 USER root
 


### PR DESCRIPTION
## Summary

Updated the DLStreamer base images to the latest 2026.2.0 RC1 release.

### Changes
- Updated Dine-In Dockerfile to use:
  - intel/dlstreamer:2026.2.0-ubuntu24-rc1
- Updated Take-Away Dockerfile to use:
  - intel/dlstreamer:2026.2.0-ubuntu24-rc1

### Validation
- Built Dine-In successfully (`make build`)
- Started Dine-In successfully (`make up`)
- Verified health endpoint
- Executed Dine-In benchmark successfully

- Built Take-Away successfully (`make build`)
- Started Take-Away successfully (`make up`)
- Verified health endpoint
- Executed Take-Away benchmark successfully

No functional changes were made apart from updating the DLStreamer base image.