### PR TITLE
Release 2026.2.0-rc1: bump Dine-In and Take-Away image tags

### DIFF
--- a/dine-in/.env.example
+++ b/dine-in/.env.example
@@ -110,4 +110,4 @@ OVMS_MODELS_DIR=../ovms-service/models
 # OVMS_CACHE_DIR: OVMS OpenVINO cache directory
 OVMS_CACHE_DIR=../ovms-service/cache
 
-TAG=2026.1.0
+TAG=2026.2.0-rc1

--- a/dine-in/Makefile
+++ b/dine-in/Makefile
@@ -67,14 +67,14 @@ endif
 COMPOSE_FILE ?= docker-compose.yaml
 
 # Version tag for registry images
-export TAG = 2026.1.0
+export TAG = 2026.2.0-rc1
 
 # Dine-In image configuration
 DINEIN_IMAGE_NAME ?= intel/order-accuracy-dine-in
 # Tag for the dine-in image only. Kept separate from TAG because TAG also
 # selects the benchmark image (intel/retail-benchmark:$(TAG)), which is
 # published per-version and has no "latest" tag.
-DINEIN_TAG ?= latest
+DINEIN_TAG ?= 2026.2.0-rc1
 DINEIN_IMAGE ?= $(DINEIN_IMAGE_NAME):$(DINEIN_TAG)
 
 # Host user identity, passed to the container so the app user is remapped to

--- a/dine-in/README.md
+++ b/dine-in/README.md
@@ -85,7 +85,7 @@ make up REGISTRY=false
 
 | Image                          | Tag        |
 | ------------------------------ | ---------- |
-| `intel/order-accuracy-dine-in` | `2026.1.0` |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
 
 ### 4. Access Services
 

--- a/dine-in/docker-compose.yaml
+++ b/dine-in/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
 
   # Dine-In Order Accuracy Gradio UI
   dine-in:
-    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:latest}
+    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc1}
     build:
       context: .
       dockerfile: Dockerfile
@@ -120,7 +120,7 @@ services:
   # Scale with: docker compose up -d --scale dinein-worker=4
   # Or set WORKERS env variable and use profile: docker compose --profile benchmark up -d
   dinein-worker:
-    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:latest}
+    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc1}
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/user-guide/dine-in/get-started/build-from-source.md
+++ b/docs/user-guide/dine-in/get-started/build-from-source.md
@@ -55,7 +55,7 @@ make build
 make build REGISTRY=false
 ```
 
-`make build REGISTRY=false` builds `intel/order-accuracy-dine-in:2026.1.0` from the local Dockerfile.
+`make build REGISTRY=false` builds `intel/order-accuracy-dine-in:2026.2.0-rc1` from the local Dockerfile.
 
 > **Note:** `ovms-vlm`, `semantic-service`, and `metrics-collector` are always pulled from their registries — they have no local build context.
 

--- a/docs/user-guide/dine-in/how-it-works.md
+++ b/docs/user-guide/dine-in/how-it-works.md
@@ -90,7 +90,7 @@ This document provides a comprehensive technical overview of the system architec
 
 | Container                 | Image                                    | Ports      | Description                         |
 | ------------------------- | ---------------------------------------- | ---------- | ----------------------------------- |
-| `dinein_app`              | `intel/order-accuracy-dine-in:2026.1.0`  | 7861, 8083 | Main application (Gradio + FastAPI) |
+| `dinein_app`              | `intel/order-accuracy-dine-in:2026.2.0-rc1`  | 7861, 8083 | Main application (Gradio + FastAPI) |
 | `dinein_ovms_vlm`         | `openvino/model_server:latest-gpu`       | 8002       | Vision-Language Model server        |
 | `dinein_semantic_service` | `intel/semantic-search-agent:2026.1.0`   | 8081, 9091 | Semantic text matching              |
 | `metrics-collector`       | `intel/hl-ai-metrics-collector:2026.1.0` | 8084       | System metrics aggregation          |

--- a/docs/user-guide/dine-in/release-notes.md
+++ b/docs/user-guide/dine-in/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes: Dine-In Order Accuracy
 
+## Version 2026.2.0-rc1
+
+### What's New
+
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+
+### Published Images
+
+| Image                           | Tag              |
+| ------------------------------- | ---------------- |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
+
+---
+
 ## Version 2026.0.0 (March 2026)
 
 **General Availability Release**

--- a/docs/user-guide/take-away/get-started/build-from-source.md
+++ b/docs/user-guide/take-away/get-started/build-from-source.md
@@ -44,10 +44,10 @@ This builds:
 
 | Service        | Image                                          |
 | -------------- | ---------------------------------------------- |
-| order-accuracy | `intel/order-accuracy-take-away:2026.1.0`      |
-| frame-selector | `intel/order-accuracy-frame-selector:2026.1.0` |
-| gradio-ui      | `intel/order-accuracy-take-away-ui:2026.1.0`   |
-| rtsp-streamer  | `intel/order-accuracy-take-away-rtsp:2026.1.0` |
+| order-accuracy | `intel/order-accuracy-take-away:2026.2.0-rc1`      |
+| frame-selector | `intel/order-accuracy-frame-selector:2026.2.0-rc1` |
+| gradio-ui      | `intel/order-accuracy-take-away-ui:2026.2.0-rc1`   |
+| rtsp-streamer  | `intel/order-accuracy-take-away-rtsp:2026.2.0-rc1` |
 
 > **Note:** `semantic-service` and OVMS (`openvino/model_server`) are always pulled — they have no local build context.
 

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -4,6 +4,23 @@ Version history and changelog for Take-Away Order Accuracy.
 
 ---
 
+## Version 2026.2.0-rc1
+
+### What's New
+
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+
+### Published Images
+
+| Image                                 | Tag             |
+| -------------------------------------- | --------------- |
+| `intel/order-accuracy-take-away`      | `2026.2.0-rc1` |
+| `intel/order-accuracy-frame-selector` | `2026.2.0-rc1` |
+| `intel/order-accuracy-take-away-ui`   | `2026.2.0-rc1` |
+| `intel/order-accuracy-take-away-rtsp` | `2026.2.0-rc1` |
+
+---
+
 ## Version 2026.1.0 (Unreleased)
 
 ### What's New

--- a/take-away/.env.example
+++ b/take-away/.env.example
@@ -209,4 +209,4 @@ MODELS_DIR=./models
 # CONFIG_DIR: Application config (orders.json, inventory.json, application.yaml)
 CONFIG_DIR=./config
 
-TAG=2026.1.0
+TAG=2026.2.0-rc1

--- a/take-away/Makefile
+++ b/take-away/Makefile
@@ -59,7 +59,7 @@ OOM_PROTECTION ?= 1
 PERF_TOOLS_DIR ?= ../performance-tools/benchmark-scripts
 
 # Version tag for registry images
-export TAG ?= 2026.1.0
+export TAG ?= 2026.2.0-rc1
 
 # Sample video for quick-start testing (orders 384 → 651 → 925)
 # Hosted on the upstream repo's GitHub Releases. Override via env if needed:

--- a/take-away/docker-compose.yaml
+++ b/take-away/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
   # SINGLE Station (per-container): docker compose up -d --scale order-accuracy=4
   # MULTI Station (multi-process in one container): Set SERVICE_MODE=parallel
   order-accuracy:
-    image: ${TAKEAWAY_IMAGE:-intel/order-accuracy-take-away:latest}
+    image: ${TAKEAWAY_IMAGE:-intel/order-accuracy-take-away:2026.2.0-rc1}
     build:
       context: .
       args:
@@ -195,7 +195,7 @@ services:
       - order-accuracy-net
 
   frame-selector:
-    image: ${FRAME_SELECTOR_IMAGE:-intel/order-accuracy-frame-selector:latest}
+    image: ${FRAME_SELECTOR_IMAGE:-intel/order-accuracy-frame-selector:2026.2.0-rc1}
     build:
       context: ./frame-selector-service
       args:
@@ -243,7 +243,7 @@ services:
       - order-accuracy-net
 
   gradio-ui:
-    image: ${TAKEAWAY_UI_IMAGE:-intel/order-accuracy-take-away-ui:latest}
+    image: ${TAKEAWAY_UI_IMAGE:-intel/order-accuracy-take-away-ui:2026.2.0-rc1}
     build:
       context: ./gradio-ui
       args:
@@ -322,7 +322,7 @@ services:
   # RTSP Streamer - On-demand video streaming via MediaMTX
   # Streams start only when a GStreamer client connects — no sync needed.
   rtsp-streamer:
-    image: ${TAKEAWAY_RTSP_IMAGE:-intel/order-accuracy-take-away-rtsp:latest}
+    image: ${TAKEAWAY_RTSP_IMAGE:-intel/order-accuracy-take-away-rtsp:2026.2.0-rc1}
     build:
       context: ./rtsp-streamer
       args:


### PR DESCRIPTION
- Bump TAG/DINEIN_TAG defaults in dine-in and take-away Makefiles to 2026.2.0-rc1
- Update docker-compose.yaml default image tags for order-accuracy-dine-in, order-accuracy-take-away, order-accuracy-frame-selector, order-accuracy-take-away-ui, order-accuracy-take-away-rtsp
- Update .env.example TAG for both apps
- Update README/how-it-works/build-from-source docs with new image tags
- Add 2026.2.0-rc1 release-notes entries for both apps