### PR TITLE
fix: bump Dine-In and Take-Away image tags

### DIFF
--- a/dine-in/.env.example
+++ b/dine-in/.env.example
@@ -110,4 +110,4 @@ OVMS_MODELS_DIR=../ovms-service/models
 # OVMS_CACHE_DIR: OVMS OpenVINO cache directory
 OVMS_CACHE_DIR=../ovms-service/cache
 
-TAG=2026.2.0-rc1
+TAG=2026.2.0-rc2

--- a/dine-in/Dockerfile
+++ b/dine-in/Dockerfile
@@ -1,4 +1,4 @@
-FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc2
 
 USER root
 

--- a/dine-in/Makefile
+++ b/dine-in/Makefile
@@ -67,14 +67,14 @@ endif
 COMPOSE_FILE ?= docker-compose.yaml
 
 # Version tag for registry images
-export TAG = 2026.2.0-rc1
+export TAG = 2026.2.0-rc2
 
 # Dine-In image configuration
 DINEIN_IMAGE_NAME ?= intel/order-accuracy-dine-in
 # Tag for the dine-in image only. Kept separate from TAG because TAG also
 # selects the benchmark image (intel/retail-benchmark:$(TAG)), which is
 # published per-version and has no "latest" tag.
-DINEIN_TAG ?= 2026.2.0-rc1
+DINEIN_TAG ?= 2026.2.0-rc2
 DINEIN_IMAGE ?= $(DINEIN_IMAGE_NAME):$(DINEIN_TAG)
 
 # Host user identity, passed to the container so the app user is remapped to

--- a/dine-in/README.md
+++ b/dine-in/README.md
@@ -85,7 +85,7 @@ make up REGISTRY=false
 
 | Image                          | Tag        |
 | ------------------------------ | ---------- |
-| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc2` |
 
 ### 4. Access Services
 

--- a/dine-in/docker-compose.yaml
+++ b/dine-in/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
 
   # Dine-In Order Accuracy Gradio UI
   dine-in:
-    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc1}
+    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc2}
     build:
       context: .
       dockerfile: Dockerfile
@@ -120,7 +120,7 @@ services:
   # Scale with: docker compose up -d --scale dinein-worker=4
   # Or set WORKERS env variable and use profile: docker compose --profile benchmark up -d
   dinein-worker:
-    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc1}
+    image: ${DINEIN_IMAGE:-intel/order-accuracy-dine-in:2026.2.0-rc2}
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/user-guide/dine-in/get-started/build-from-source.md
+++ b/docs/user-guide/dine-in/get-started/build-from-source.md
@@ -55,7 +55,7 @@ make build
 make build REGISTRY=false
 ```
 
-`make build REGISTRY=false` builds `intel/order-accuracy-dine-in:2026.2.0-rc1` from the local Dockerfile.
+`make build REGISTRY=false` builds `intel/order-accuracy-dine-in:2026.2.0-rc2` from the local Dockerfile.
 
 > **Note:** `ovms-vlm`, `semantic-service`, and `metrics-collector` are always pulled from their registries — they have no local build context.
 

--- a/docs/user-guide/dine-in/how-it-works.md
+++ b/docs/user-guide/dine-in/how-it-works.md
@@ -90,7 +90,7 @@ This document provides a comprehensive technical overview of the system architec
 
 | Container                 | Image                                    | Ports      | Description                         |
 | ------------------------- | ---------------------------------------- | ---------- | ----------------------------------- |
-| `dinein_app`              | `intel/order-accuracy-dine-in:2026.2.0-rc1`  | 7861, 8083 | Main application (Gradio + FastAPI) |
+| `dinein_app`              | `intel/order-accuracy-dine-in:2026.2.0-rc2`  | 7861, 8083 | Main application (Gradio + FastAPI) |
 | `dinein_ovms_vlm`         | `openvino/model_server:latest-gpu`       | 8002       | Vision-Language Model server        |
 | `dinein_semantic_service` | `intel/semantic-search-agent:2026.1.0`   | 8081, 9091 | Semantic text matching              |
 | `metrics-collector`       | `intel/hl-ai-metrics-collector:2026.1.0` | 8084       | System metrics aggregation          |

--- a/docs/user-guide/dine-in/release-notes.md
+++ b/docs/user-guide/dine-in/release-notes.md
@@ -45,7 +45,7 @@ Promoted from `2026.0-rc2` with no code changes. All functionality is identical 
 
 ---
 
-## Version 2026.0-rc2 (March 2026)
+## Version 2026.0-rc1 (March 2026)
 
 ### New Features
 
@@ -56,16 +56,16 @@ Promoted from `2026.0-rc2` with no code changes. All functionality is identical 
   - `make up` - Run with registry image (default)
 
 - **Docker Image Tagging**: Standardized image naming
-  - Image: `intel/order-accuracy-dine-in:2026.0-rc2`
+  - Image: `intel/order-accuracy-dine-in:2026.0-rc1`
   - Configurable via `TAG` and `DINEIN_IMAGE_NAME` variables
 
 ### Configuration Changes
 
 | Variable       | Old Default | New Default                             |
 | -------------- | ----------- | --------------------------------------- |
-| `TAG`          | 1.0.0       | 2026.0-rc2                              |
+| `TAG`          | 1.0.0       | 2026.0-rc1                              |
 | `REGISTRY`     | false       | true                                    |
-| `DINEIN_IMAGE` | -           | intel/order-accuracy-dine-in:2026.0-rc2 |
+| `DINEIN_IMAGE` | -           | intel/order-accuracy-dine-in:2026.0-rc1 |
 
 ### Migration Notes
 

--- a/docs/user-guide/dine-in/release-notes.md
+++ b/docs/user-guide/dine-in/release-notes.md
@@ -1,16 +1,16 @@
 # Release Notes: Dine-In Order Accuracy
 
-## Version 2026.2.0-rc1
+## Version 2026.2.0-rc2
 
 ### What's New
 
-- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc2`.
 
 ### Published Images
 
 | Image                           | Tag              |
 | ------------------------------- | ---------------- |
-| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc2` |
 
 ---
 
@@ -45,7 +45,7 @@ Promoted from `2026.0-rc2` with no code changes. All functionality is identical 
 
 ---
 
-## Version 2026.0-rc1 (March 2026)
+## Version 2026.0-rc2 (March 2026)
 
 ### New Features
 
@@ -56,16 +56,16 @@ Promoted from `2026.0-rc2` with no code changes. All functionality is identical 
   - `make up` - Run with registry image (default)
 
 - **Docker Image Tagging**: Standardized image naming
-  - Image: `intel/order-accuracy-dine-in:2026.0-rc1`
+  - Image: `intel/order-accuracy-dine-in:2026.0-rc2`
   - Configurable via `TAG` and `DINEIN_IMAGE_NAME` variables
 
 ### Configuration Changes
 
 | Variable       | Old Default | New Default                             |
 | -------------- | ----------- | --------------------------------------- |
-| `TAG`          | 1.0.0       | 2026.0-rc1                              |
+| `TAG`          | 1.0.0       | 2026.0-rc2                              |
 | `REGISTRY`     | false       | true                                    |
-| `DINEIN_IMAGE` | -           | intel/order-accuracy-dine-in:2026.0-rc1 |
+| `DINEIN_IMAGE` | -           | intel/order-accuracy-dine-in:2026.0-rc2 |
 
 ### Migration Notes
 

--- a/docs/user-guide/dine-in/release-notes.md
+++ b/docs/user-guide/dine-in/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes: Dine-In Order Accuracy
 
-## Version 2026.2.0-rc2
+## Version 2026.2.0-rc2 (Latest)
 
 ### What's New
 
@@ -11,6 +11,20 @@
 | Image                           | Tag              |
 | ------------------------------- | ---------------- |
 | `intel/order-accuracy-dine-in` | `2026.2.0-rc2` |
+
+---
+
+## Version 2026.2.0-rc1
+
+### What's New
+
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+
+### Published Images
+
+| Image                           | Tag              |
+| ------------------------------- | ---------------- |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
 
 ---
 

--- a/docs/user-guide/take-away/get-started/build-from-source.md
+++ b/docs/user-guide/take-away/get-started/build-from-source.md
@@ -44,10 +44,10 @@ This builds:
 
 | Service        | Image                                          |
 | -------------- | ---------------------------------------------- |
-| order-accuracy | `intel/order-accuracy-take-away:2026.2.0-rc1`      |
-| frame-selector | `intel/order-accuracy-frame-selector:2026.2.0-rc1` |
-| gradio-ui      | `intel/order-accuracy-take-away-ui:2026.2.0-rc1`   |
-| rtsp-streamer  | `intel/order-accuracy-take-away-rtsp:2026.2.0-rc1` |
+| order-accuracy | `intel/order-accuracy-take-away:2026.2.0-rc2`      |
+| frame-selector | `intel/order-accuracy-frame-selector:2026.2.0-rc2` |
+| gradio-ui      | `intel/order-accuracy-take-away-ui:2026.2.0-rc2`   |
+| rtsp-streamer  | `intel/order-accuracy-take-away-rtsp:2026.2.0-rc2` |
 
 > **Note:** `semantic-service` and OVMS (`openvino/model_server`) are always pulled — they have no local build context.
 

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -4,20 +4,20 @@ Version history and changelog for Take-Away Order Accuracy.
 
 ---
 
-## Version 2026.2.0-rc1
+## Version 2026.2.0-rc2
 
 ### What's New
 
-- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc2`.
 
 ### Published Images
 
 | Image                                 | Tag             |
 | -------------------------------------- | --------------- |
-| `intel/order-accuracy-take-away`      | `2026.2.0-rc1` |
-| `intel/order-accuracy-frame-selector` | `2026.2.0-rc1` |
-| `intel/order-accuracy-take-away-ui`   | `2026.2.0-rc1` |
-| `intel/order-accuracy-take-away-rtsp` | `2026.2.0-rc1` |
+| `intel/order-accuracy-take-away`      | `2026.2.0-rc2` |
+| `intel/order-accuracy-frame-selector` | `2026.2.0-rc2` |
+| `intel/order-accuracy-take-away-ui`   | `2026.2.0-rc2` |
+| `intel/order-accuracy-take-away-rtsp` | `2026.2.0-rc2` |
 
 ---
 
@@ -89,13 +89,13 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 | `intel/order-accuracy-take-away`      | `2026.0-rc2` |
 | `intel/order-accuracy-frame-selector` | `2026.0-rc2` |
 | `intel/order-accuracy-take-away-ui`   | `2026.0-rc2` |
-| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc1` |
+| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc2` |
 
-> `rtsp-streamer` image tag remains `2026.0-rc1` — no changes in this release.
+> `rtsp-streamer` image tag remains `2026.0-rc2` — no changes in this release.
 
 ---
 
-## Version 2026.0-rc1 (March 2026)
+## Version 2026.0-rc2 (March 2026)
 
 **Initial Release Candidate**
 
@@ -112,10 +112,10 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 
 | Image                                 | Tag          | Size   |
 | ------------------------------------- | ------------ | ------ |
-| `intel/order-accuracy-take-away`      | `2026.0-rc1` | 9.64GB |
-| `intel/order-accuracy-frame-selector` | `2026.0-rc1` | 1.96GB |
-| `intel/order-accuracy-take-away-ui`   | `2026.0-rc1` | 1.3GB  |
-| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc1` | 227MB  |
+| `intel/order-accuracy-take-away`      | `2026.0-rc2` | 9.64GB |
+| `intel/order-accuracy-frame-selector` | `2026.0-rc2` | 1.96GB |
+| `intel/order-accuracy-take-away-ui`   | `2026.0-rc2` | 1.3GB  |
+| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc2` | 227MB  |
 
 ### Features
 

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -95,7 +95,7 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 
 ---
 
-## Version 2026.0-rc2 (March 2026)
+## Version 2026.0-rc1 (March 2026)
 
 **Initial Release Candidate**
 
@@ -112,10 +112,10 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 
 | Image                                 | Tag          | Size   |
 | ------------------------------------- | ------------ | ------ |
-| `intel/order-accuracy-take-away`      | `2026.0-rc2` | 9.64GB |
-| `intel/order-accuracy-frame-selector` | `2026.0-rc2` | 1.96GB |
-| `intel/order-accuracy-take-away-ui`   | `2026.0-rc2` | 1.3GB  |
-| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc2` | 227MB  |
+| `intel/order-accuracy-take-away`      | `2026.0-rc1` | 9.64GB |
+| `intel/order-accuracy-frame-selector` | `2026.0-rc1` | 1.96GB |
+| `intel/order-accuracy-take-away-ui`   | `2026.0-rc1` | 1.3GB  |
+| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc1` | 227MB  |
 
 ### Features
 

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -29,9 +29,12 @@ Version history and changelog for Take-Away Order Accuracy.
 
 ### Published Images
 
-| Image                           | Tag              |
-| ------------------------------- | ---------------- |
-| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
+| Image                                 | Tag             |
+| -------------------------------------- | --------------- |
+| `intel/order-accuracy-take-away`      | `2026.2.0-rc1` |
+| `intel/order-accuracy-frame-selector` | `2026.2.0-rc1` |
+| `intel/order-accuracy-take-away-ui`   | `2026.2.0-rc1` |
+| `intel/order-accuracy-take-away-rtsp` | `2026.2.0-rc1` |
 
 ---
 

--- a/docs/user-guide/take-away/release-notes.md
+++ b/docs/user-guide/take-away/release-notes.md
@@ -4,7 +4,7 @@ Version history and changelog for Take-Away Order Accuracy.
 
 ---
 
-## Version 2026.2.0-rc2
+## Version 2026.2.0-rc2 (Latest)
 
 ### What's New
 
@@ -18,6 +18,20 @@ Version history and changelog for Take-Away Order Accuracy.
 | `intel/order-accuracy-frame-selector` | `2026.2.0-rc2` |
 | `intel/order-accuracy-take-away-ui`   | `2026.2.0-rc2` |
 | `intel/order-accuracy-take-away-rtsp` | `2026.2.0-rc2` |
+
+---
+
+## Version 2026.2.0-rc1
+
+### What's New
+
+- **DLStreamer base image updated** to `intel/dlstreamer:2026.2.0-ubuntu24-rc1`.
+
+### Published Images
+
+| Image                           | Tag              |
+| ------------------------------- | ---------------- |
+| `intel/order-accuracy-dine-in` | `2026.2.0-rc1` |
 
 ---
 
@@ -89,9 +103,9 @@ This is the first GA release of Take-Away Order Accuracy, promoted from `2026.0-
 | `intel/order-accuracy-take-away`      | `2026.0-rc2` |
 | `intel/order-accuracy-frame-selector` | `2026.0-rc2` |
 | `intel/order-accuracy-take-away-ui`   | `2026.0-rc2` |
-| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc2` |
+| `intel/order-accuracy-take-away-rtsp` | `2026.0-rc1` |
 
-> `rtsp-streamer` image tag remains `2026.0-rc2` — no changes in this release.
+> `rtsp-streamer` image tag remains `2026.0-rc1` — no changes in this release.
 
 ---
 

--- a/take-away/.env.example
+++ b/take-away/.env.example
@@ -209,4 +209,4 @@ MODELS_DIR=./models
 # CONFIG_DIR: Application config (orders.json, inventory.json, application.yaml)
 CONFIG_DIR=./config
 
-TAG=2026.2.0-rc1
+TAG=2026.2.0-rc2

--- a/take-away/Dockerfile
+++ b/take-away/Dockerfile
@@ -1,4 +1,4 @@
-FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc2
 
 USER root
 

--- a/take-away/Makefile
+++ b/take-away/Makefile
@@ -59,12 +59,12 @@ OOM_PROTECTION ?= 1
 PERF_TOOLS_DIR ?= ../performance-tools/benchmark-scripts
 
 # Version tag for registry images
-export TAG ?= 2026.2.0-rc1
+export TAG ?= 2026.2.0-rc2
 
 # Sample video for quick-start testing (orders 384 → 651 → 925)
 # Hosted on the upstream repo's GitHub Releases. Override via env if needed:
 #   SAMPLE_VIDEO_URL=<url> make download-sample-video
-SAMPLE_VIDEO_URL ?= https://github.com/intel-retail/order-accuracy/releases/download/2026.0-rc1/test.mp4
+SAMPLE_VIDEO_URL ?= https://github.com/intel-retail/order-accuracy/releases/download/2026.0-rc2/test.mp4
 SAMPLE_VIDEO_DEST ?= storage/videos/test.mp4
 
 # Registry configuration: true=pull from registry, false=build locally

--- a/take-away/Makefile
+++ b/take-away/Makefile
@@ -64,7 +64,7 @@ export TAG ?= 2026.2.0-rc2
 # Sample video for quick-start testing (orders 384 → 651 → 925)
 # Hosted on the upstream repo's GitHub Releases. Override via env if needed:
 #   SAMPLE_VIDEO_URL=<url> make download-sample-video
-SAMPLE_VIDEO_URL ?= https://github.com/intel-retail/order-accuracy/releases/download/2026.0-rc2/test.mp4
+SAMPLE_VIDEO_URL ?= https://github.com/intel-retail/order-accuracy/releases/download/2026.0-rc1/test.mp4
 SAMPLE_VIDEO_DEST ?= storage/videos/test.mp4
 
 # Registry configuration: true=pull from registry, false=build locally
@@ -346,7 +346,7 @@ build: check-env
 		docker compose -f $(COMPOSE_FILE) --profile parallel build; \
 	else \
 		echo "$(YELLOW)REGISTRY=true → Pulling images from registry...$(NC)"; \
-		docker compose -f $(COMPOSE_FILE) pull order-accuracy frame-selector gradio-ui rtsp-streamer; \
+		docker compose -f $(COMPOSE_FILE) pull order-accuracy frame-selector gradio-ui rtsp-streamer metrics-collector; \
 	fi
 	@echo "$(GREEN)✓ Build complete$(NC)"
 

--- a/take-away/docker-compose.yaml
+++ b/take-away/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
   # SINGLE Station (per-container): docker compose up -d --scale order-accuracy=4
   # MULTI Station (multi-process in one container): Set SERVICE_MODE=parallel
   order-accuracy:
-    image: ${TAKEAWAY_IMAGE:-intel/order-accuracy-take-away:2026.2.0-rc1}
+    image: ${TAKEAWAY_IMAGE:-intel/order-accuracy-take-away:2026.2.0-rc2}
     build:
       context: .
       args:
@@ -195,7 +195,7 @@ services:
       - order-accuracy-net
 
   frame-selector:
-    image: ${FRAME_SELECTOR_IMAGE:-intel/order-accuracy-frame-selector:2026.2.0-rc1}
+    image: ${FRAME_SELECTOR_IMAGE:-intel/order-accuracy-frame-selector:2026.2.0-rc2}
     build:
       context: ./frame-selector-service
       args:
@@ -243,7 +243,7 @@ services:
       - order-accuracy-net
 
   gradio-ui:
-    image: ${TAKEAWAY_UI_IMAGE:-intel/order-accuracy-take-away-ui:2026.2.0-rc1}
+    image: ${TAKEAWAY_UI_IMAGE:-intel/order-accuracy-take-away-ui:2026.2.0-rc2}
     build:
       context: ./gradio-ui
       args:
@@ -322,7 +322,7 @@ services:
   # RTSP Streamer - On-demand video streaming via MediaMTX
   # Streams start only when a GStreamer client connects — no sync needed.
   rtsp-streamer:
-    image: ${TAKEAWAY_RTSP_IMAGE:-intel/order-accuracy-take-away-rtsp:2026.2.0-rc1}
+    image: ${TAKEAWAY_RTSP_IMAGE:-intel/order-accuracy-take-away-rtsp:2026.2.0-rc2}
     build:
       context: ./rtsp-streamer
       args:

--- a/take-away/docker-compose.yaml
+++ b/take-away/docker-compose.yaml
@@ -355,9 +355,6 @@ services:
       - order-accuracy-net
 
   metrics-collector:
-    build:
-      context: ../performance-tools/docker
-      dockerfile: Dockerfile
     image: intel/retail-benchmark:${TAG}
     container_name: metrics-collector
     profiles:

--- a/take-away/docker-compose.yaml
+++ b/take-away/docker-compose.yaml
@@ -355,6 +355,9 @@ services:
       - order-accuracy-net
 
   metrics-collector:
+    build:
+      context: ../performance-tools/docker
+      dockerfile: Dockerfile
     image: intel/retail-benchmark:${TAG}
     container_name: metrics-collector
     profiles:


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/loss-prevention/blob/main/CONTRIBUTING.md
- [x] Every commit is a single defect fix and does not mix feature addition or changes
- [ ] Unit Tests have been added for new changes
- [ ] Updated Documentation as relevant to the changes
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with repository license and clearly outlined the added dependency.
- [x] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)

## What are you changing?
updated dlstreamer and other image tags to rc2

## Issue this PR will close

close: updated image tags

## Anything the reviewer should know when reviewing this PR?

## Test Instructions if applicable

- dine-in :

setup model
make build,
make up,
make logs,
make test-api,
validated APIs by curl
make benchmark-single IMAGE_ID=MCD-1001
make benchmark
validated images and their metrics by UI

- take-away:

setup model
make build
make up
make logs
make test-api
make status
validated APIs by curl
make benchmark
tested video upload, processing and order recall by UI

## If the there are associated PRs in other repositories, please link them here (i.e. intel-retail/loss-prevention )
